### PR TITLE
Fix ${callsite} when using DI logger

### DIFF
--- a/src/NLog.Extensions.Logging/AspNetExtensions.cs
+++ b/src/NLog.Extensions.Logging/AspNetExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
@@ -20,6 +20,8 @@ namespace NLog.Extensions.Logging
         public static ILoggerFactory AddNLog(this ILoggerFactory factory)
         {
             //ignore this
+            LogManager.AddHiddenAssembly(Assembly.Load(new AssemblyName("Microsoft.Extensions.Logging")));
+            LogManager.AddHiddenAssembly(Assembly.Load(new AssemblyName("Microsoft.Extensions.Logging.Abstractions")));
             LogManager.AddHiddenAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
 
             using (var provider = new NLogLoggerProvider())

--- a/src/NLog.Extensions.Logging/project.json
+++ b/src/NLog.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0-rtm-alpha2",
+    "version": "1.0.0-rtm-alpha3",
     "description": "NLog provider for Microsoft.Extensions.Logging",
     "authors": [ "Microsoft", "Julian Verdurmen" ],
     "packOptions": {


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog/issues/1512

```c#
//typeof logger: NLog.Logger
Logger.Info("Index page says hello");
```

this wasn't working:

```c#
//typeof _logger: Microsoft.Extensions.Logging.ILogger
 _logger.LogInformation("info 2 with DI");
```



Example log with fix:

```
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestStarting | Request starting HTTP/1.1 GET http://localhost:59915/  
Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware.Invoke | The request path / does not match a supported file type
Microsoft.AspNetCore.Routing.Logging.TreeRouterLoggerExtensions.MatchedRoute | Request successfully matched the route with name 'default' and template '{controller=Home}/{action=Index}/{id?}'.
Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeAsync | Executing action aspnet_core_example.Controllers.HomeController.Index (aspnet-core-example)
Microsoft.AspNetCore.Mvc.Internal.MvcCoreLoggerExtensions.ActionMethodExecuting | Executing action method aspnet_core_example.Controllers.HomeController.Index (aspnet-core-example) with arguments () - ModelState is Valid
aspnet_core_example.Controllers.HomeController.Index | Index page says hello
aspnet_core_example.Controllers.HomeController.Index | info 2 with DI
aspnet_core_example.Controllers.HomeController.Index | DI: zero: 0 two: 1 one: 2
Microsoft.AspNetCore.Mvc.Internal.MvcCoreLoggerExtensions.ActionMethodExecuted | Executed action method aspnet_core_example.Controllers.HomeController.Index (aspnet-core-example), returned result Microsoft.AspNetCore.Mvc.ViewResult.
Microsoft.AspNetCore.Mvc.Razor.Internal.MvcRazorLoggerExtensions.ViewLookupCacheHit | View lookup cache hit for view 'Index' in controller 'Home'.
Microsoft.AspNetCore.Mvc.ViewFeatures.Internal.ViewResultExecutor.FindView | The view 'Index' was found.
Microsoft.AspNetCore.Mvc.ViewFeatures.Internal.ViewResultExecutor.ExecuteAsync | Executing ViewResult, running view at path /Views/Home/Index.cshtml.
Microsoft.AspNetCore.Mvc.Razor.Internal.MvcRazorLoggerExtensions.ViewLookupCacheHit | View lookup cache hit for view '_Layout' in controller 'Home'.
Microsoft.AspNetCore.Mvc.Internal.MvcCoreLoggerExtensions.ExecutedAction | Executed action aspnet_core_example.Controllers.HomeController.Index (aspnet-core-example) in 102.491ms
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestFinished | Request finished in 159.3279ms 200 text/html; charset=utf-8
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestStarting | Request starting HTTP/1.1 GET http://localhost:59915/lib/bootstrap/dist/js/bootstrap.js  
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestStarting | Request starting HTTP/1.1 GET http://localhost:59915/lib/bootstrap/dist/css/bootstrap.css  
Microsoft.AspNetCore.Server.Kestrel.Internal.Http.Connection.Microsoft.AspNetCore.Server.Kestrel.Internal.Http.IConnectionControl.End | Connection id "0HKTBC8R7PHUK" completed keep alive response.
Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware.Invoke | The file /lib/bootstrap/dist/js/bootstrap.js was not modified
Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware.Invoke | The file /lib/bootstrap/dist/css/bootstrap.css was not modified
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestStarting | Request starting HTTP/1.1 GET http://localhost:59915/js/site.js?v=EWaMeWsJBYWmL2g_KkgXZQ5nPe-a3Ichp0LEgzXczKo  
Microsoft.AspNetCore.StaticFiles.LoggerExtensions.LogHandled | Handled. Status code: 304 File: /lib/bootstrap/dist/js/bootstrap.js
Microsoft.AspNetCore.StaticFiles.LoggerExtensions.LogHandled | Handled. Status code: 304 File: /lib/bootstrap/dist/css/bootstrap.css
Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware.Invoke | The file /js/site.js was not modified
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestFinished | Request finished in 164.5949ms 304 application/javascript
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestFinished | Request finished in 179.6334ms 304 text/css
Microsoft.AspNetCore.StaticFiles.LoggerExtensions.LogHandled | Handled. Status code: 304 File: /js/site.js
Microsoft.AspNetCore.Server.Kestrel.Internal.Http.Connection.Microsoft.AspNetCore.Server.Kestrel.Internal.Http.IConnectionControl.End | Connection id "0HKTBC8R7PHUL" completed keep alive response.
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestStarting | Request starting HTTP/1.1 GET http://localhost:59915/images/banner1.svg  
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestFinished | Request finished in 145.0956ms 304 application/javascript
Microsoft.AspNetCore.Hosting.Internal.HostingLoggerExtensions.RequestStarting | Request starting HTTP/1.1 GET http://localhost:59915/lib/jquery/dist/jquery.js  
Microsoft.AspNetCore.Server.Kestrel.Internal.Http.Connection.Microsoft.AspNetCore.Server.Kestrel.Internal.Http.IConnectionControl.End | Connection id "0HKTBC8R7PHUM" completed keep alive response.
Microsoft.AspNetCore.Server.Kestrel.Internal.Http.Connection.Microsoft.AspNetCore.Server.Kestrel.Internal.Http.IConnectionControl.End | Connection id "0HKTBC8R7PHUK" completed keep alive response.
Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware.Invoke | The file /lib/jquery/dist/jquery.js was not modified


```