### PR TITLE
Fix problem with "." in property names, by using "_"

### DIFF
--- a/src/NLog.Extensions.Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/NLogLogger.cs
@@ -32,8 +32,8 @@ namespace NLog.Extensions.Logging
                     //message arguments are not needed as it is already checked that the loglevel is enabled.
                     var eventInfo = LogEventInfo.Create(nLogLogLevel, _logger.Name, message);
                     eventInfo.Exception = exception;
-                    eventInfo.Properties["EventId.Id"] = eventId.Id;
-                    eventInfo.Properties["EventId.Name"] = eventId.Name;
+                    eventInfo.Properties["EventId_Id"] = eventId.Id;
+                    eventInfo.Properties["EventId_Name"] = eventId.Name;
                     eventInfo.Properties["EventId"] = eventId;
                     _logger.Log(eventInfo);
                 }


### PR DESCRIPTION
This pull request fixes issue where "." isn't allowed for property names when using ElasticSearch. I uses a "_" instead.

Does this match a proper pull request?

Best Regards,

Mark Monster

fixes https://github.com/NLog/NLog.Extensions.Logging/issues/64
