### PR TITLE
introduce basic structured logging capabilities by adding all message…

### DIFF
--- a/src/NLog.Extensions.Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/NLogLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace NLog.Extensions.Logging
@@ -35,6 +36,15 @@ namespace NLog.Extensions.Logging
                     eventInfo.Properties["EventId.Id"] = eventId.Id;
                     eventInfo.Properties["EventId.Name"] = eventId.Name;
                     eventInfo.Properties["EventId"] = eventId;
+
+
+                    // Extract all arguments passed in state and add them as event properties
+                    var metadata = state as IEnumerable<KeyValuePair<string, object>>;
+                    foreach (var item in metadata)
+                    {
+                        eventInfo.Properties[item.Key] = item.Value;
+                    }
+
                     _logger.Log(eventInfo);
                 }
             }


### PR DESCRIPTION
Introduce basic structured logging capabilities by adding all message arguments to the NLog event properties dictionary. All arguments can then easily retrieved and formatted individually via NLog.config settings. i.e. ${event-properties:item=requestElapsedTime}