### PR TITLE
Added NLog provider options - EventIdSeparator

### DIFF
--- a/src/NLog.Extensions.Logging/AspNetExtensions.cs
+++ b/src/NLog.Extensions.Logging/AspNetExtensions.cs
@@ -26,7 +26,7 @@ namespace NLog.Extensions.Logging
 
             try
             {
-                //try the Filter extensin
+                //try the Filter ext
                 var filterAssembly = Assembly.Load(new AssemblyName("Microsoft.Extensions.Logging.Filter"));
                 LogManager.AddHiddenAssembly(filterAssembly);
             }

--- a/src/NLog.Extensions.Logging/AspNetExtensions.cs
+++ b/src/NLog.Extensions.Logging/AspNetExtensions.cs
@@ -12,13 +12,23 @@ namespace NLog.Extensions.Logging
     /// </summary>
     public static class AspNetExtensions
     {
-
         /// <summary>
         /// Enable NLog as logging provider in ASP.NET Core.
         /// </summary>
         /// <param name="factory"></param>
         /// <returns></returns>
         public static ILoggerFactory AddNLog(this ILoggerFactory factory)
+        {
+            return AddNLog(factory, null);
+        }
+
+        /// <summary>
+        /// Enable NLog as logging provider in ASP.NET Core.
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <param name="options">NLog options</param>
+        /// <returns></returns>
+        public static ILoggerFactory AddNLog(this ILoggerFactory factory, NLogProviderOptions options)
         {
             //ignore this
             LogManager.AddHiddenAssembly(Assembly.Load(new AssemblyName("Microsoft.Extensions.Logging")));
@@ -37,7 +47,7 @@ namespace NLog.Extensions.Logging
           
             LogManager.AddHiddenAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
 
-            using (var provider = new NLogLoggerProvider())
+            using (var provider = new NLogLoggerProvider(options))
             {
                 factory.AddProvider(provider);
             }

--- a/src/NLog.Extensions.Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/NLogLogger.cs
@@ -9,10 +9,12 @@ namespace NLog.Extensions.Logging
     internal class NLogLogger : Microsoft.Extensions.Logging.ILogger
     {
         private readonly Logger _logger;
+        private readonly NLogProviderOptions _options;
 
-        public NLogLogger(Logger logger)
+        public NLogLogger(Logger logger, NLogProviderOptions options)
         {
             _logger = logger;
+            _options = options ?? NLogProviderOptions.Default;
         }
 
         //todo  callsite showing the framework logging classes/methods
@@ -32,8 +34,8 @@ namespace NLog.Extensions.Logging
                     //message arguments are not needed as it is already checked that the loglevel is enabled.
                     var eventInfo = LogEventInfo.Create(nLogLogLevel, _logger.Name, message);
                     eventInfo.Exception = exception;
-                    eventInfo.Properties["EventId.Id"] = eventId.Id;
-                    eventInfo.Properties["EventId.Name"] = eventId.Name;
+                    eventInfo.Properties["EventId" + _options.EventIdSeparator + "Id"] = eventId.Id;
+                    eventInfo.Properties["EventId" + _options.EventIdSeparator + "Name"] = eventId.Name;
                     eventInfo.Properties["EventId"] = eventId;
                     _logger.Log(eventInfo);
                 }
@@ -67,7 +69,7 @@ namespace NLog.Extensions.Logging
         private static LogLevel ConvertLogLevel(Microsoft.Extensions.Logging.LogLevel logLevel)
         {
             switch (logLevel)
-            {                
+            {
                 case Microsoft.Extensions.Logging.LogLevel.Trace:
                     return LogLevel.Trace;
                 case Microsoft.Extensions.Logging.LogLevel.Debug:

--- a/src/NLog.Extensions.Logging/NLogLoggerProvider.cs
+++ b/src/NLog.Extensions.Logging/NLogLoggerProvider.cs
@@ -6,10 +6,24 @@
     public class NLogLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider
     {
         /// <summary>
+        /// NLog options
+        /// </summary>
+        public NLogProviderOptions Options { get; set; }
+
+        /// <summary>
         /// <see cref="NLogLoggerProvider"/> with default options.
         /// </summary>
-        public NLogLoggerProvider()
+        public NLogLoggerProvider() 
         {
+        }
+
+        /// <summary>
+        /// <see cref="NLogLoggerProvider"/> with default options.
+        /// </summary>
+        /// <param name="options"></param>
+        public NLogLoggerProvider(NLogProviderOptions options)
+        {
+            Options = options;
         }
 
         /// <summary>
@@ -19,7 +33,7 @@
         /// <returns>New Logger</returns>
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string name)
         {
-            return new NLogLogger(LogManager.GetLogger(name));
+            return new NLogLogger(LogManager.GetLogger(name), Options);
         }
 
         /// <summary>

--- a/src/NLog.Extensions.Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/NLogProviderOptions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NLog.Extensions.Logging
+{
+    public class NLogProviderOptions
+    {
+        /// <summary>
+        /// Separator between for EventId.Id and EventId.Name. Default to .
+        /// </summary>
+        public string EventIdSeparator { get; set; }
+
+        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        public NLogProviderOptions()
+        {
+            EventIdSeparator = ".";
+        }
+
+        /// <summary>
+        /// Default options
+        /// </summary>
+        internal static NLogProviderOptions Default = new NLogProviderOptions();
+    }
+}

--- a/src/NLog.Extensions.Logging/project.json
+++ b/src/NLog.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-rtm-alpha4",
+  "version": "1.0.0-rtm-alpha5",
   "description": "NLog provider for Microsoft.Extensions.Logging",
   "authors": [ "Microsoft", "Julian Verdurmen" ],
   "packOptions": {

--- a/src/NLog.Extensions.Logging/project.json
+++ b/src/NLog.Extensions.Logging/project.json
@@ -28,12 +28,12 @@
         "System.Xml.Serialization": "4.0.0.0"
       },
       "dependencies": {
-        "NLog": "4.3.5"
+        "NLog": "4.3.11"
       }
     },
     "netstandard1.3": {
       "dependencies": {
-        "NLog": "4.4.0-beta12"
+        "NLog": "5.0.0-beta03"
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog.Extensions.Logging/issues/64

Usage:

```C#
loggerFactory.AddNLog(new NLogProviderOptions {EventIdSeparator = "_"});
```