### PR TITLE
created extension to try get EventId

### DIFF
--- a/src/NLog.Extensions.Logging/LogEventInfoExtensions.cs
+++ b/src/NLog.Extensions.Logging/LogEventInfoExtensions.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Logging;
+
+namespace NLog.Extensions.Logging
+{
+
+    public static class LogEventInfoExtensions {
+
+
+        /// <summary>
+        /// Gets the <see cref="Microsoft.Extensions.Logging.EventId"/>. If it was not included in the log 
+        /// event, then uses the default value.
+        /// </summary>
+        /// <param name="logEvent"></param>
+        /// <param name="defaultValue"></param>
+        /// <returns></returns>
+        public static EventId getEventId(this LogEventInfo logEvent, EventId defaultValue = default(EventId))
+        {
+
+            if (!logEvent.HasProperties)
+                return defaultValue;
+
+            // setup key names the same way "NLogLogger.cs" does it
+            var options = new NLogProviderOptions();
+            var idKey = $"EventId{options.EventIdSeparator}Id";
+            var nameKey = $"EventId{options.EventIdSeparator}Name";
+
+            // try get EventId properties or use defaults
+            var id = (logEvent.Properties.ContainsKey(idKey)) ? (int)logEvent.Properties[idKey] : defaultValue.Id;
+            var name = (logEvent.Properties.ContainsKey(nameKey)) ? logEvent.Properties[nameKey].ToString() : defaultValue.Name;
+
+            return new EventId(id, name);
+        }
+
+
+    }
+}

--- a/src/NLog.Extensions.Logging/LogEventInfoExtensions.cs
+++ b/src/NLog.Extensions.Logging/LogEventInfoExtensions.cs
@@ -26,7 +26,7 @@ namespace NLog.Extensions.Logging
 
             // try get EventId properties or use defaults
             var id = (logEvent.Properties.ContainsKey(idKey)) ? (int)logEvent.Properties[idKey] : defaultValue.Id;
-            var name = (logEvent.Properties.ContainsKey(nameKey)) ? logEvent.Properties[nameKey].ToString() : defaultValue.Name;
+            var name = (logEvent.Properties.ContainsKey(nameKey)) ? logEvent.Properties[nameKey]?.ToString() : defaultValue.Name;
 
             return new EventId(id, name);
         }


### PR DESCRIPTION
When using .NET Core logging, there is [an `EventId` struct](http://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.Abstractions/EventId.cs) for the [log event's contextual info](http://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging#log-event-id).

[NLog captures it](http://github.com/NLog/NLog.Extensions.Logging/blob/master/src/NLog.Extensions.Logging/NLogLogger.cs#L35) into the `LogEventInfo.Properties` dictionary, but it is a bother to extract it again. Lots of checks and casting and so on.

This extension method makes it easy. And if the log event does not include the struct, then a safe default is returned.