### PR TITLE
Update dependencies (NLog 5 - beta6)

### DIFF
--- a/src/NLog.Extensions.Logging/project.json
+++ b/src/NLog.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-rtm-beta3",
+  "version": "1.0.0-rtm-beta4",
   "description": "NLog provider for Microsoft.Extensions.Logging",
   "authors": [ "Microsoft", "Julian Verdurmen" ],
   "packOptions": {
@@ -30,12 +30,12 @@
         
       },
       "dependencies": {
-        "NLog": "4.4.2"
+        "NLog": "4.4.3"
       }
     },
     "netstandard1.3": {
       "dependencies": {
-        "NLog": "5.0.0-beta05",
+        "NLog": "5.0.0-beta06",
         "System.AppContext": "4.3.0"
       },
       "buildOptions": {"define": ["NETCORE"]}

--- a/src/NLog.Extensions.Logging/project.json
+++ b/src/NLog.Extensions.Logging/project.json
@@ -11,7 +11,7 @@
       "type": "git",
       "url": "git://github.com/NLog/NLog.Extensions.Logging"
     },
-    "releaseNotes": "Fix installation issues on .NET 4.6+"
+    "releaseNotes": "Update dependencies"
   },
 
   "buildOptions": {


### PR DESCRIPTION
Because beta5 has known issues with archiving. See #100 