### PR TITLE
Update LogEventInfo properties with log paramters

### DIFF
--- a/src/NLog.Extensions.Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/NLogLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace NLog.Extensions.Logging
@@ -37,6 +38,21 @@ namespace NLog.Extensions.Logging
                     eventInfo.Properties["EventId" + _options.EventIdSeparator + "Id"] = eventId.Id;
                     eventInfo.Properties["EventId" + _options.EventIdSeparator + "Name"] = eventId.Name;
                     eventInfo.Properties["EventId"] = eventId;
+
+                    var structure = state as IEnumerable<KeyValuePair<string, object>>;
+                    if (structure != null)
+                    {
+                        foreach (var property in structure)
+                        {
+                            if(property.Key == _options.OriginalFormatPropertyName)
+                            {
+                                continue;
+                            }
+
+                            eventInfo.Properties.Add(property.Key, property.Value);
+                        }
+                    }
+
                     _logger.Log(eventInfo);
                 }
             }

--- a/src/NLog.Extensions.Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/NLogProviderOptions.cs
@@ -12,10 +12,13 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public string EventIdSeparator { get; set; }
 
+        public string OriginalFormatPropertyName { get; set; }
+
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
         public NLogProviderOptions()
         {
             EventIdSeparator = ".";
+            OriginalFormatPropertyName = "{OriginalFormat}";
         }
 
         /// <summary>


### PR DESCRIPTION
If the user logs `_logger.LogInformation("Getting item {ID} at {RequestTime}", id, DateTime.Now);`, `TState state` parameter contains 3 key-values which could be used for structured logging.

- ID = id
- RequestTime = DateTime.Now
- {OriginalFormat} = Getting item id at DateTime.Now

This PR adds the values to the LogEventInfo's properties so that the parameters could be used to filter when the target supports structured logging - i.e. Graylog, ELK.
