### PR TITLE
switch from NestedDiagnosticsContext to NestedDiagnosticsLogicalContext

### DIFF
--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="NLog" Version="4.4.9" />
+    <PackageReference Include="NLog" Version="4.4.11" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Xml.Serialization" />
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="NLog" Version="5.0.0-beta07" />
+    <PackageReference Include="NLog" Version="5.0.0-beta09" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/NLog.Extensions.Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/NLogLogger.cs
@@ -102,7 +102,7 @@ namespace NLog.Extensions.Logging
                 throw new ArgumentNullException(nameof(state));
             }
             
-            return NestedDiagnosticsContext.Push(state);
+            return NestedDiagnosticsLogicalContext.Push(state);
         }
     }
 }


### PR DESCRIPTION
In order to be use properly from asp.net core we need to use NestedDiagnosticsLogicalContext fro BeginScope method.

-----
upgrade NLog version
switch from NestedDiagnosticsContext to NestedDiagnosticsLogicalContext

fixes https://github.com/NLog/NLog.Extensions.Logging/issues/10