### PR TITLE
Minimize string-allocations when adding EventId-properties

### DIFF
--- a/src/NLog.Extensions.Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/NLogProviderOptions.cs
@@ -12,6 +12,11 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public string EventIdSeparator { get; set; }
 
+        /// <summary>
+        /// Skip allocation of <see cref="LogEventInfo.Properties" />-dictionary when <see cref="default(EventId)"/>
+        /// </summary>
+        public bool IgnoreEmptyEventId { get; set; }
+
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
         public NLogProviderOptions()
         {


### PR DESCRIPTION
Following memory optimizations:

- Skip four property-name-string-allocations for every LogEvent
- Skip boxing of default EventId-struct for every LogEvent
- Skip boxing of zero-EventId-value for every LogEvent

Added new NLogProviderOptions.IgnoreEmptyEventId (default = false), so it skips LogEventInfo.Properties-Dictionary-allocation for every LogEvent (when no EventId)