### PR TITLE
Capture structured logging parameter names

### DIFF
--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -56,7 +56,7 @@ For ASP.NET Core, use NLog.Web.AspNetCore: https://www.nuget.org/packages/NLog.W
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="NLog" Version="4.5.0-beta02" />
+    <PackageReference Include="NLog" Version="4.5.0-beta06" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/NLog.Extensions.Logging/NLogMessageParameterList.cs
+++ b/src/NLog.Extensions.Logging/NLogMessageParameterList.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NLog.Extensions.Logging
+{
+#if NETSTANDARD2_0
+    /// <summary>
+    /// Converts Microsoft Extension Logging ParameterList into NLog MessageTemplate ParameterList
+    /// </summary>
+    internal class NLogMessageParameterList : IList<NLog.MessageTemplates.MessageTemplateParameter>
+    {
+        private IReadOnlyList<KeyValuePair<string, object>> _parameterList;
+
+        public NLogMessageParameterList(IReadOnlyList<KeyValuePair<string, object>> parameterList, bool includesOriginalMessage)
+        {
+            List<KeyValuePair<string, object>> validParameterList = includesOriginalMessage ? null : new List<KeyValuePair<string, object>>();
+            for (int i = 0; i < parameterList.Count; ++i)
+            {
+                if (!string.IsNullOrEmpty(parameterList[i].Key) && (parameterList[i].Key != NLogLogger.OriginalFormatPropertyName || i == parameterList.Count - 1))
+                {
+                    if (validParameterList != null)
+                    {
+                        if (parameterList[i].Key != NLogLogger.OriginalFormatPropertyName)
+                            validParameterList.Add(parameterList[i]);
+                    }
+                }
+                else
+                {
+                    if (validParameterList == null)
+                    {
+                        validParameterList = new List<KeyValuePair<string, object>>();
+                        for (int j = 0; j < i; ++i)
+                            validParameterList.Add(parameterList[j]);
+                    }
+                }
+            }
+            if (validParameterList != null)
+            {
+                validParameterList.Add(new KeyValuePair<string, object>());
+            }
+            _parameterList = validParameterList ?? parameterList;
+        }
+
+        public NLog.MessageTemplates.MessageTemplateParameter this[int index]
+        {
+            get
+            {
+                var parameter = _parameterList[index];
+                var parameterName = parameter.Key;
+                NLog.MessageTemplates.CaptureType captureType = NLog.MessageTemplates.CaptureType.Normal;
+                switch (parameterName[0])
+                {
+                    case '@':
+                        parameterName = parameterName.Substring(1); 
+                        captureType = NLog.MessageTemplates.CaptureType.Serialize;
+                        break;
+                    case '$':
+                        parameterName = parameterName.Substring(1); 
+                        captureType = NLog.MessageTemplates.CaptureType.Stringify;
+                        break;
+                }
+                return new NLog.MessageTemplates.MessageTemplateParameter(parameter.Key, parameter.Value, null, captureType);
+            }
+            set => throw new NotImplementedException();
+        }
+
+        public int Count => _parameterList.Count - 1;
+
+        public bool IsReadOnly => true;
+
+        public void Add(NLog.MessageTemplates.MessageTemplateParameter item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Contains(NLog.MessageTemplates.MessageTemplateParameter item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CopyTo(NLog.MessageTemplates.MessageTemplateParameter[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerator<NLog.MessageTemplates.MessageTemplateParameter> GetEnumerator()
+        {
+            return _parameterList.Take(_parameterList.Count - 1).Select(p => new NLog.MessageTemplates.MessageTemplateParameter(p.Key, p.Value, null)).GetEnumerator();
+        }
+
+        public int IndexOf(NLog.MessageTemplates.MessageTemplateParameter item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Insert(int index, NLog.MessageTemplates.MessageTemplateParameter item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(NLog.MessageTemplates.MessageTemplateParameter item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+#endif
+}

--- a/src/NLog.Extensions.Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/NLogProviderOptions.cs
@@ -22,6 +22,11 @@ namespace NLog.Extensions.Logging
         ///     <c>default(EventId)</c></remarks>
         public bool IgnoreEmptyEventId { get; set; }
 
+        /// <summary>
+        /// Attempt to capture parameter names and values and insert into <see cref="LogEventInfo.Properties" />-dictionary
+        /// </summary>
+        public bool EnableStructuredLogging { get; set; }
+
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
         public NLogProviderOptions()
         {

--- a/test/LoggerTests.cs
+++ b/test/LoggerTests.cs
@@ -24,7 +24,6 @@ namespace NLog.Extensions.Logging.Tests
 
             var target = GetTarget();
             Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|init runner |0", target.Logs.FirstOrDefault());
-           
         }
 
         [Fact]
@@ -34,7 +33,24 @@ namespace NLog.Extensions.Logging.Tests
 
             var target = GetTarget();
             Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|message with id |20", target.Logs.FirstOrDefault());
-           
+        }
+
+        [Fact]
+        public void TestParameters()
+        {
+            GetRunner().LogDebugWithParameters();
+
+            var target = GetTarget();
+            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|message with id and 1 parameters |0", target.Logs.FirstOrDefault());
+        }
+
+        [Fact]
+        public void TestStructuredLogging()
+        {
+            GetRunner().LogDebugWithStructuredParameters();
+
+            var target = GetTarget();
+            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|message with id and 1 parameters |01", target.Logs.FirstOrDefault());
         }
 
         [Theory]
@@ -152,11 +168,10 @@ namespace NLog.Extensions.Logging.Tests
             var serviceProvider = services.BuildServiceProvider();
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
 
-            loggerFactory.AddNLog();
+            loggerFactory.AddNLog(new NLogProviderOptions() { EnableStructuredLogging = true });
             loggerFactory.ConfigureNLog("nlog.config");
             return serviceProvider;
         }
-
 
         public class Runner
         {
@@ -166,7 +181,6 @@ namespace NLog.Extensions.Logging.Tests
             {
                 _logger = fac.CreateLogger<Runner>();
             }
-
 
             public void LogDebugWithId()
             {
@@ -200,6 +214,16 @@ namespace NLog.Extensions.Logging.Tests
                 }
             }
 
+            public void LogDebugWithParameters()
+            {
+                _logger.LogDebug("message with id and {0} parameters", "1");
+            }
+
+            public void LogDebugWithStructuredParameters()
+            {
+                _logger.LogDebug("message with id and {ParameterCount} parameters", "1");
+            }
+
             public void LogWithScope()
             {
                 using (_logger.BeginScope("scope1"))
@@ -211,7 +235,6 @@ namespace NLog.Extensions.Logging.Tests
             public void Init()
             {
                 _logger.LogDebug("init runner");
-
             }
         }
     }

--- a/test/NLog.Extensions.Logging.Tests.csproj
+++ b/test/NLog.Extensions.Logging.Tests.csproj
@@ -22,7 +22,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="NLog" Version="4.5.0-beta02" />
+    <PackageReference Include="NLog" Version="4.5.0-beta06" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/nlog.config
+++ b/test/nlog.config
@@ -8,7 +8,7 @@
   <targets>
     <!-- write logs to file -->
     <target xsi:type="Memory" name="target1"
-            layout="${logger}|${uppercase:${level}}|${message} ${exception}|${event-properties:EventId}" />
+            layout="${logger}|${uppercase:${level}}|${message} ${exception}|${event-properties:EventId}${event-properties:ParameterCount}" />
 
   </targets>
 


### PR DESCRIPTION
Extracted from Microsoft FormattedLogValues. Allowing NLog to support structured logging using the Microsoft-parser-engine. Resolves #116

P.S. Funny detail discovered while digging around in the Microsoft-machine-room (Notice the static ConcurrentDictionary and limit of 1024)

https://github.com/aspnet/Logging/blob/cc503aaed0b9fb3e93345b28629e80581337d3c1/src/Microsoft.Extensions.Logging.Abstractions/Internal/FormattedLogValues.cs

P.P.S. Surprised that they are not using the StringComparer.Ordinal for the ConcurrentDictionary 