### PR TITLE
MessageTemplate  - Structured logging parameters (Better option name)

### DIFF
--- a/src/NLog.Extensions.Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/NLogLogger.cs
@@ -37,7 +37,7 @@ namespace NLog.Extensions.Logging
             }
             var message = formatter(state, exception);
 
-            var messageTemplate = _options.EnableStructuredLogging ? state as IReadOnlyList<KeyValuePair<string, object>> : null;
+            var messageTemplate = _options.CaptureMessageTemplates ? state as IReadOnlyList<KeyValuePair<string, object>> : null;
             LogEventInfo eventInfo = CreateLogEventInfo(nLogLogLevel, message, messageTemplate);
             eventInfo.Exception = exception;
             if (!_options.IgnoreEmptyEventId || eventId.Id != 0 || !string.IsNullOrEmpty(eventId.Name))

--- a/src/NLog.Extensions.Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/NLogProviderOptions.cs
@@ -23,9 +23,9 @@ namespace NLog.Extensions.Logging
         public bool IgnoreEmptyEventId { get; set; }
 
         /// <summary>
-        /// Attempt to capture parameter names and values and insert into <see cref="LogEventInfo.Properties" />-dictionary
+        /// Enable structured logging by capturing message template parameters and inject into the <see cref="LogEventInfo.Properties" />-dictionary
         /// </summary>
-        public bool EnableStructuredLogging { get; set; }
+        public bool CaptureMessageTemplates { get; set; }
 
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
         public NLogProviderOptions()

--- a/test/LoggerTests.cs
+++ b/test/LoggerTests.cs
@@ -168,7 +168,7 @@ namespace NLog.Extensions.Logging.Tests
             var serviceProvider = services.BuildServiceProvider();
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
 
-            loggerFactory.AddNLog(new NLogProviderOptions() { EnableStructuredLogging = true });
+            loggerFactory.AddNLog(new NLogProviderOptions() { CaptureMessageTemplates = true });
             loggerFactory.ConfigureNLog("nlog.config");
             return serviceProvider;
         }


### PR DESCRIPTION
CaptureMessageTemplate better matches the suggested ParseMessageTemplate-config-name.

See also https://github.com/NLog/NLog/issues/2347