### PR TITLE
MessageProperties - Allow capture of message properties (CaptureMessageProperties option)

### DIFF
--- a/src/NLog.Extensions.Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/NLogProviderOptions.cs
@@ -27,6 +27,11 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public bool CaptureMessageTemplates { get; set; }
 
+        /// <summary>
+        /// Enable capture of properties from the ILogger-State-object, both in <see cref="Microsoft.Extensions.Logging.ILogger.Log"/> and <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope"/>
+        /// </summary>
+        public bool CaptureMessageProperties { get; set; }
+
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
         public NLogProviderOptions()
         {

--- a/test/nlog.config
+++ b/test/nlog.config
@@ -8,7 +8,7 @@
   <targets>
     <!-- write logs to file -->
     <target xsi:type="Memory" name="target1"
-            layout="${logger}|${uppercase:${level}}|${message} ${exception}|${event-properties:EventId}${event-properties:ParameterCount}" />
+            layout="${logger}|${uppercase:${level}}|${message} ${exception}|${event-properties:EventId}${event-properties:ParameterCount}${mdlc:item=scope1}" />
 
   </targets>
 


### PR DESCRIPTION
Using ILogger-state and ILogger-scope. Resolves https://github.com/NLog/NLog/issues/1366