### PR TITLE
NLogProviderOptions: added IgnoreEmptyEventId, set default EventIdSeparator to underscore.

### DIFF
--- a/src/NLog.Extensions.Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/NLogProviderOptions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace NLog.Extensions.Logging
 {
@@ -30,7 +28,8 @@ namespace NLog.Extensions.Logging
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
         public NLogProviderOptions()
         {
-            EventIdSeparator = ".";
+            EventIdSeparator = "_";
+            IgnoreEmptyEventId = true;
         }
 
         /// <summary>

--- a/test/LoggerTests.cs
+++ b/test/LoggerTests.cs
@@ -23,7 +23,7 @@ namespace NLog.Extensions.Logging.Tests
             GetRunner().Init();
 
             var target = GetTarget();
-            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|init runner |0", target.Logs.FirstOrDefault());
+            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|init runner |", target.Logs.FirstOrDefault());
         }
 
         [Fact]
@@ -41,7 +41,7 @@ namespace NLog.Extensions.Logging.Tests
             GetRunner().LogDebugWithParameters();
 
             var target = GetTarget();
-            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|message with id and 1 parameters |0", target.Logs.FirstOrDefault());
+            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|message with id and 1 parameters |", target.Logs.FirstOrDefault());
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace NLog.Extensions.Logging.Tests
             GetRunner().LogDebugWithStructuredParameters();
 
             var target = GetTarget();
-            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|message with id and 1 parameters |01", target.Logs.FirstOrDefault());
+            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|message with id and 1 parameters |1", target.Logs.FirstOrDefault());
         }
 
         [Theory]


### PR DESCRIPTION
IgnoreEmptyEventId = true and default EventIdSeparator to underscore.

Resolves #150  + #149 