### PR TITLE
Depends on NetFx.Extensions.* instead of Microsoft.Extensions.* for n…

### DIFF
--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -18,7 +18,7 @@ For ASP.NET Core, use NLog.Web.AspNetCore: https://www.nuget.org/packages/NLog.W
 
 rc2 (see https://github.com/NLog/NLog.Extensions.Logging/milestone/9?closed=1)
 - Fix Recursive resource lookup bug
-- Disallow NLog 5 for platforms dependend on NLog 4
+- Disallow NLog 5 for platforms depended on NLog 4
 
 
     </PackageReleaseNotes>
@@ -35,18 +35,9 @@ rc2 (see https://github.com/NLog/NLog.Extensions.Logging/milestone/9?closed=1)
     <!-- FileVersion = AssemblyFileVersionAttribute, patched by AppVeyor -->
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="NLog" Version="[4.4.12,5)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Xml.Serialization" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="NLog" Version="[4.4.12,5)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="NetFx.Extensions.Logging.Abstractions" Version="2.0.0" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Xml.Serialization" />

--- a/test/NLog.Extensions.Logging.Tests.csproj
+++ b/test/NLog.Extensions.Logging.Tests.csproj
@@ -28,8 +28,8 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="NLog" Version="4.4.12" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="NetFx.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="NetFx.Extensions.Logging" Version="2.0.0" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Xml.Serialization" />


### PR DESCRIPTION
For issue #169 

`Microsoft.Extensions.Logging` depends on NetStandard library, which introduce many unnecessary dll for full NetFx. `NetFx.Extensions.*` is designed for NetFx but provide equivalent functionality to `Microsoft.Extensions.*`
