### PR TITLE
Implement .NET standard 2 features for .NET 4.6.1 + update dependencies

### DIFF
--- a/examples/NetCore2/ConsoleExample/ConsoleExample.csproj
+++ b/examples/NetCore2/ConsoleExample/ConsoleExample.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="NLog" Version="4.5.0-beta07" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLog.Extensions.Logging/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/ConfigureExtensions.cs
@@ -40,8 +40,7 @@ namespace NLog.Extensions.Logging
             return factory;
         }
 
-#if NETSTANDARD2_0
-
+#if !NETCORE1_0
         /// <summary>
         /// Enable NLog as logging provider in .NET Core.
         /// </summary>
@@ -75,6 +74,9 @@ namespace NLog.Extensions.Logging
             try
             {
                 //ignore these assemblies for ${callsite}
+#if !NETCORE1_0
+                LogManager.AddHiddenAssembly(typeof(Microsoft.Extensions.Logging.ILoggingBuilder).GetTypeInfo().Assembly); //Microsoft.Logging
+#endif
                 LogManager.AddHiddenAssembly(typeof(Microsoft.Extensions.Logging.LoggerFactoryExtensions).GetTypeInfo().Assembly); //Microsoft.Extensions.Logging
                 LogManager.AddHiddenAssembly(typeof(Microsoft.Extensions.Logging.ILogger).GetTypeInfo().Assembly); // Microsoft.Extensions.Logging.Abstractions
                 LogManager.AddHiddenAssembly(typeof(NLog.Extensions.Logging.ConfigureExtensions).GetTypeInfo().Assembly); //NLog.Extensions.Logging
@@ -106,8 +108,7 @@ namespace NLog.Extensions.Logging
         /// <returns>Current configuration for chaining.</returns>
         public static LoggingConfiguration ConfigureNLog(this ILoggerFactory loggerFactory, string configFileRelativePath)
         {
-
-#if NETCORE
+#if NETCORE1_0 && !NET451
             var rootPath = System.AppContext.BaseDirectory;
 #else
             var rootPath = AppDomain.CurrentDomain.BaseDirectory;

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -45,7 +45,7 @@ rc2 (see https://github.com/NLog/NLog.Extensions.Logging/milestone/9?closed=1)
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="NLog" Version="[4.4.12,5)" />
+    <PackageReference Include="NLog" Version="[4.5-rc01,5)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Runtime" />
@@ -53,8 +53,8 @@ rc2 (see https://github.com/NLog/NLog.Extensions.Logging/milestone/9?closed=1)
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard1.5' Or '$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard1.5' Or '$(TargetFramework)' == 'net451'">
+    <DefineConstants>$(DefineConstants);NETCORE1_0</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\NLog.Extensions.Logging.xml</DocumentationFile>
@@ -66,12 +66,11 @@ rc2 (see https://github.com/NLog/NLog.Extensions.Logging/milestone/9?closed=1)
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
-    <PackageReference Include="NLog" Version="[4.5.0-beta07,5)" />
+    <PackageReference Include="NLog" Version="[4.5.0-rc01,5)" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="NLog" Version="[4.5.0-beta07,5)" />
-    <PackageReference Include="System.AppContext" Version="4.3.0" />
+    <PackageReference Include="NLog" Version="[4.5.0-rc01,5)" />
   </ItemGroup>
 </Project>

--- a/src/NLog.Extensions.Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/NLogLogger.cs
@@ -60,7 +60,7 @@ namespace NLog.Extensions.Logging
                 {
                     if (firstParameterName.Length != 1 || !char.IsDigit(firstParameterName[0]))
                     {
-#if NETSTANDARD2_0
+#if !NETSTANDARD1_3
                         var originalFormat = parameterList[parameterList.Count - 1];
                         string originalMessage = null;
                         if (originalFormat.Key == OriginalFormatPropertyName)

--- a/src/NLog.Extensions.Logging/NLogMessageParameterList.cs
+++ b/src/NLog.Extensions.Logging/NLogMessageParameterList.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace NLog.Extensions.Logging
 {
-#if NETSTANDARD2_0
+#if !NETSTANDARD1_3
     /// <summary>
     /// Converts Microsoft Extension Logging ParameterList into NLog MessageTemplate ParameterList
     /// </summary>

--- a/test/NLog.Extensions.Logging.Tests.csproj
+++ b/test/NLog.Extensions.Logging.Tests.csproj
@@ -1,40 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+
     <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
-
-
-
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
-    <PackageReference Include="NLog" Version="4.5.0-beta07" />
-    <PackageReference Include="System.AppContext" Version="4.3.0" />
   </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="NLog" Version="4.5.0-beta07" />
-    <PackageReference Include="System.AppContext" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="NLog" Version="4.4.12" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Xml.Serialization" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
supersedes #171 

.NET 4.5 is still NLog 4.4.x+