### PR TITLE
Create Test Case with Example of Formatting

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -84,14 +84,17 @@ namespace NLog.Extensions.Logging
             return logEvent;
         }
 
-        private static void SetLogEventMessageFormatter(LogEventInfo logEvent, NLogMessageParameterList messageTemplateParameters, string formattedMessage)
+        private  void SetLogEventMessageFormatter(LogEventInfo logEvent, NLogMessageParameterList messageTemplateParameters, string formattedMessage)
         {
             var parameters = new object[messageTemplateParameters.Count + 1];
             for (int i = 0; i < parameters.Length - 1; ++i)
                 parameters[i] = messageTemplateParameters[i].Value;
             parameters[parameters.Length - 1] = formattedMessage;
             logEvent.Parameters = parameters;
-            logEvent.MessageFormatter = (l) => (string)l.Parameters[l.Parameters.Length - 1];
+            if (!_options.CaptureMessageProperties && !_options.CaptureMessageTemplates)
+            {
+                logEvent.MessageFormatter = (l) => (string)l.Parameters[l.Parameters.Length - 1];
+            }
         }
 
         private void CaptureEventId(LogEventInfo eventInfo, EventId eventId)

--- a/test/LoggerTests.cs
+++ b/test/LoggerTests.cs
@@ -273,7 +273,7 @@ namespace NLog.Extensions.Logging.Tests
 
             public void LogDebugWithStructuredParameters()
             {
-                _logger.LogDebug("message with id and {$ParameterCount} parameters", "1");
+                _logger.LogDebug("message with id and {ParameterCount} parameters", "1");
             }
 
             public void LogDebugWithStructuredParameterFormater()

--- a/test/LoggerTests.cs
+++ b/test/LoggerTests.cs
@@ -51,7 +51,7 @@ namespace NLog.Extensions.Logging.Tests
             GetRunner().LogDebugWithStructuredParameters();
 
             var target = GetTarget();
-            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|message with id and 1 parameters |1", target.Logs.FirstOrDefault());
+            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|message with id and \"1\" parameters |1", target.Logs.FirstOrDefault());
         }
 
         [Fact]
@@ -184,9 +184,9 @@ namespace NLog.Extensions.Logging.Tests
         public void TestStructuredLoggingFormatting()
         {
             GetRunner().LogDebugWithStructuredParameterFormater();
-
+            
             var target = GetJsonlayoutTarget();
-            Assert.Equal(@"{""level"": ""DEBUG"", ""message"": ""message with id and {""TestValue"": ""This is the test value""}"" }", target.Logs.FirstOrDefault());
+            Assert.Equal("{ \"level\": \"DEBUG\", \"message\": \"message with id and {\\\"TestValue\\\":\\\"This is the test value\\\"} parameters\" }", target.Logs.FirstOrDefault());
         }
 
 
@@ -273,7 +273,7 @@ namespace NLog.Extensions.Logging.Tests
 
             public void LogDebugWithStructuredParameters()
             {
-                _logger.LogDebug("message with id and {ParameterCount} parameters", "1");
+                _logger.LogDebug("message with id and {$ParameterCount} parameters", "1");
             }
 
             public void LogDebugWithStructuredParameterFormater()

--- a/test/LoggerTests.cs
+++ b/test/LoggerTests.cs
@@ -179,7 +179,17 @@ namespace NLog.Extensions.Logging.Tests
             var target = GetTarget();
             Assert.Equal(expectedLogMessage, target.Logs.FirstOrDefault()); 
         }
-        
+
+        [Fact]
+        public void TestStructuredLoggingFormatting()
+        {
+            GetRunner().LogDebugWithStructuredParameterFormater();
+
+            var target = GetJsonlayoutTarget();
+            Assert.Equal(@"{""level"": ""DEBUG"", ""message"": ""message with id and {""TestValue"": ""This is the test value""}"" }", target.Logs.FirstOrDefault());
+        }
+
+
         private static Runner GetRunner()
         {
             var serviceProvider = ServiceProvider.Value;
@@ -192,6 +202,11 @@ namespace NLog.Extensions.Logging.Tests
         private static MemoryTarget GetTarget()
         {
             var target = LogManager.Configuration.FindTargetByName<MemoryTarget>("target1");
+            return target;
+        }
+        private static MemoryTarget GetJsonlayoutTarget()
+        {
+            var target = LogManager.Configuration.FindTargetByName<MemoryTarget>("target2");
             return target;
         }
 
@@ -261,6 +276,11 @@ namespace NLog.Extensions.Logging.Tests
                 _logger.LogDebug("message with id and {ParameterCount} parameters", "1");
             }
 
+            public void LogDebugWithStructuredParameterFormater()
+            {
+                _logger.LogDebug("message with id and {@ObjectParameter} parameters", new TestObject());
+            }
+
             public void LogDebugWithSimulatedStructuredParameters()
             {
                 _logger.Log(Microsoft.Extensions.Logging.LogLevel.Debug, default(EventId), new List<KeyValuePair<string, object>>(new [] { new KeyValuePair<string,object>("{OriginalFormat}", "message with id and {ParameterCount} property"), new KeyValuePair<string, object>("ParameterCount", 1) }), null, (s, ex) => "message with id and 1 property");
@@ -296,6 +316,11 @@ namespace NLog.Extensions.Logging.Tests
             {
                 _logger.LogDebug("init runner");
             }
+        }
+
+        public class TestObject
+        {
+            public string TestValue { get; set; } = "This is the test value";
         }
     }
 }

--- a/test/nlog.config
+++ b/test/nlog.config
@@ -9,12 +9,17 @@
     <!-- write logs to file -->
     <target xsi:type="Memory" name="target1"
             layout="${logger}|${uppercase:${level}}|${message} ${exception}|${event-properties:EventId}${event-properties:ParameterCount}${mdlc:item=scope1}" />
-
+    <target xsi:type="Memory" name="target2">
+      <layout type="JsonLayout" maxRecursionLimit="10">
+        <attribute name="level" layout="${uppercase:${level}}" />
+        <attribute name="message" layout="${message}" />
+      </layout>
+    </target>
   </targets>
 
   <!-- rules to map from logger name to target -->
   <rules>
-    <logger name="*" minlevel="Trace" writeTo="target1" />
+    <logger name="*" minlevel="Trace" writeTo="target1,target2" />
 
   </rules>
 </nlog>


### PR DESCRIPTION
Example failing test case for what I think may be a bug. 

I am trying to setup structured logging. when I add a template parameter to messages and call Nlog directly the log files show the message as I would expect. However when called using NLog.Extensions.Logging the message never gets formatted; only ToString is called.  
Expected: 
```C#
_logger.LogDebug("message with id and {@ObjectParameter} parameters", new TestObject());
```
```javascript
{"level": "DEBUG", "message": "message with id and {"TestValue": "This is the test value"}  parameters" }
```
Actual:
 ```javascript
{"level": "DEBUG", "message": "message with id and NLog.Extensions.Logging.Tests.LoggerTests+TestObject parameters" }
```

I am more then willing to help with a fix if this is really a bug and not me misunderstanding.
