### PR TITLE
CallSite should recognize all Microsoft.Extensions.Logging.ILogger

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -9,7 +9,7 @@ $versionProduct = $versionPrefix;
 if (-Not $versionSuffix.Equals(""))
 	{ $versionProduct = $versionProduct + "-" + $versionSuffix }
 
-msbuild /t:Restore,Pack .\src\NLog.Extensions.Logging\ /p:targetFrameworks='"net451;net461;netstandard1.5;netstandard2.0;uap10.0"' /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal
+msbuild /t:Restore,Pack .\src\NLog.Extensions.Logging\ /p:targetFrameworks='"net451;net461;netstandard1.3;netstandard1.5;netstandard2.0"' /p:VersionPrefix=$versionPrefix /p:VersionSuffix=$versionSuffix /p:FileVersion=$versionFile /p:ProductVersion=$versionProduct /p:Configuration=Release /p:IncludeSymbols=true /p:PackageOutputPath=..\..\artifacts /verbosity:minimal
 if (-Not $LastExitCode -eq 0)
 	{ exit $LastExitCode }
 

--- a/examples/NetCore2/ConsoleExample/nlog.config
+++ b/examples/NetCore2/ConsoleExample/nlog.config
@@ -6,21 +6,17 @@
       internalLogFile="c:\temp\console-example-internal.log"
       internalLogLevel="Info" >
 
-
   <!-- the targets to write to -->
   <targets>
     <!-- write logs to file -->
-    <target xsi:type="File" name="target1" fileName="c:\temp\console-example.log"
-            layout="${date}|${level:uppercase=true}|${message} ${exception}|${logger}|${all-event-properties}" />
-    <target xsi:type="Console" name="target2"
-            layout="${date}|${level:uppercase=true}|${message} ${exception}|${logger}|${all-event-properties}" />
-
-
+    <target xsi:type="File" name="fileTarget" fileName="c:\temp\console-example.log"
+            layout="${date}|${level:uppercase=true}|${message} ${exception:format=tostring}|${logger}|${all-event-properties}" />
+    <target xsi:type="Console" name="consoleTarget"
+            layout="${date}|${level:uppercase=true}|${message} ${exception:format=tostring}|${logger}|${all-event-properties}" />
   </targets>
 
   <!-- rules to map from logger name to target -->
   <rules>
-    <logger name="*" minlevel="Trace" writeTo="target1,target2" />
-
+    <logger name="*" minlevel="Trace" writeTo="fileTarget,consoleTarget" />
   </rules>
 </nlog>

--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -108,6 +108,7 @@ namespace NLog.Extensions.Logging
         /// <param name="loggerFactory"></param>
         /// <param name="configFileRelativePath">relative path to NLog configuration file.</param>
         /// <returns>Current configuration for chaining.</returns>
+        [Obsolete("Instead use NLog.LogManager.LoadConfiguration()")]
         public static LoggingConfiguration ConfigureNLog(this ILoggerFactory loggerFactory, string configFileRelativePath)
         {
             ConfigureHiddenAssemblies();
@@ -120,6 +121,7 @@ namespace NLog.Extensions.Logging
         /// <param name="loggerFactory"></param>
         /// <param name="config">New NLog config.</param>
         /// <returns>Current configuration for chaining.</returns>
+        [Obsolete("Instead assign property NLog.LogManager.Configuration")]
         public static LoggingConfiguration ConfigureNLog(this ILoggerFactory loggerFactory, LoggingConfiguration config)
         {
             ConfigureHiddenAssemblies();

--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -51,7 +51,7 @@ namespace NLog.Extensions.Logging
                 CaptureMessageProperties(eventInfo, state);
             }
 
-            _logger.Log(eventInfo);
+            _logger.Log(typeof(Microsoft.Extensions.Logging.ILogger), eventInfo);
         }
 
 

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks>net451;net461;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;net461;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     
@@ -43,6 +43,11 @@ rc3: Support for .NET 4.6.1, support for message templates .NET standard 1.5+ an
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <DefineConstants>$(DefineConstants);NETCORE1_0</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <Title>NLog.Extensions.Logging for NetStandard 1.3</Title>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+    <DefineConstants>$(DefineConstants);NETCORE1_0</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <Title>NLog.Extensions.Logging for NetStandard 1.5</Title>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
@@ -51,20 +56,8 @@ rc3: Support for .NET 4.6.1, support for message templates .NET standard 1.5+ an
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <Title>NLog.Extensions.Logging for NetStandard 2.0</Title>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <Title>NLog.Extensions.Logging for UWP</Title>
-    <NugetTargetMoniker>UAP,Version=v10.0</NugetTargetMoniker>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <TargetFrameworkIdentifier>.NETCore</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
-    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.15083.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
-    <DefineConstants>$(DefineConstants);NETCORE1_0</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="[4.5.0-rc06,5)" />
+    <PackageReference Include="NLog" Version="[4.5.0-rc07,5)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.2" />
@@ -76,7 +69,7 @@ rc3: Support for .NET 4.6.1, support for message templates .NET standard 1.5+ an
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/test/CustomLoggerCallSiteTest.cs
+++ b/test/CustomLoggerCallSiteTest.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace NLog.Extensions.Logging.Tests
+{
+    public class CustomLoggerCallSiteTest : NLogTestBase
+    {
+        [Fact]
+        public void TestCallSiteSayHello()
+        {
+            ConfigureServiceProvider<CustomLoggerCallSiteTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
+            var runner = GetRunner<CustomLoggerCallSiteTestRunner>();
+
+            var target = new NLog.Targets.MemoryTarget() { Layout = "${callsite}|${message}" };
+            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            runner.SayHello();
+            Assert.Single(target.Logs);
+            Assert.Contains("SayHello", target.Logs[0]);
+            Assert.Contains("stuff", target.Logs[0]);
+        }
+
+        public class SameAssemblyLogger<T> : ILogger<T>
+        {
+            private readonly Microsoft.Extensions.Logging.ILogger _logger;
+
+            public SameAssemblyLogger(ILoggerFactory loggerFactory)
+            {
+                _logger = loggerFactory.CreateLogger<T>();
+            }
+
+            public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                string Formatter(TState innserState, Exception innerException)
+                {
+                    // additional logic for all providers goes here
+                    var message = formatter(innserState, innerException) ?? string.Empty;
+                    return message + " additional stuff in here";
+                }
+
+                _logger.Log(logLevel, eventId, state, exception, Formatter);
+            }
+
+            public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
+            {
+                return _logger.IsEnabled(logLevel);
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return _logger.BeginScope(state);
+            }
+        }
+
+        public class CustomLoggerCallSiteTestRunner
+        {
+            private readonly ILogger<CustomLoggerCallSiteTestRunner> _logger;
+
+            public CustomLoggerCallSiteTestRunner(ILogger<CustomLoggerCallSiteTestRunner> logger)
+            {
+                _logger = logger;
+            }
+
+            public void SayHello()
+            {
+                _logger.LogInformation("Hello");
+            }
+        }
+
+    }
+}

--- a/test/NLogTestBase.cs
+++ b/test/NLogTestBase.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace NLog.Extensions.Logging.Tests
+{
+    public class NLogTestBase
+    {
+        IServiceProvider _serviceProvider;
+
+        protected IServiceProvider ConfigureServiceProvider<T>(Action<ServiceCollection> configureServices = null, NLogProviderOptions options = null) where T : class
+        {
+            if (_serviceProvider == null)
+            {
+                var services = new ServiceCollection();
+
+                services.AddTransient<T>();
+                services.AddSingleton<ILoggerFactory, LoggerFactory>();
+                services.AddSingleton(typeof(ILogger<>), typeof(Logger<>));
+                configureServices?.Invoke(services);
+
+                _serviceProvider = services.BuildServiceProvider();
+
+                var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+                loggerFactory.AddNLog(options ?? new NLogProviderOptions() { CaptureMessageTemplates = true, CaptureMessageProperties = true });
+            }
+            return _serviceProvider;
+        }
+
+        protected T GetRunner<T>(NLogProviderOptions options = null) where T : class
+        {
+            // Start program
+            var runner = ConfigureServiceProvider<T>(null, options).GetRequiredService<T>();
+            return runner;
+        }
+    }
+}

--- a/test/Properties/AssemblyInfo-test.cs
+++ b/test/Properties/AssemblyInfo-test.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
Completed the callsite-fix, that started with https://github.com/NLog/NLog/pull/2609

Also made it easier to add new unit-test-classes, instead of all being based on the same NLog.config.