### PR TITLE
Add Alias attribute to NLogLoggerProvider

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
@@ -1,8 +1,15 @@
-﻿namespace NLog.Extensions.Logging
+﻿#if !NETCORE1_0
+using Microsoft.Extensions.Logging;
+#endif
+
+namespace NLog.Extensions.Logging
 {
     /// <summary>
     /// Provider logger for NLog + Microsoft.Extensions.Logging
     /// </summary>
+ #if !NETCORE1_0
+    [ProviderAlias("NLog")]
+#endif
     public class NLogLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider
     {
         /// <summary>


### PR DESCRIPTION
Added the Microsoft.Extensions.Logging.ProviderAliasAttribute to the NLogLoggerProvider to enable it to be used Logging Configuration instead of having to supply the full name of the provider class.