### PR TITLE
fixed ConfigureHiddenAssemblies not working for .NET Core 2.0

### DIFF
--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -69,7 +69,7 @@ namespace NLog.Extensions.Logging
         /// </summary>
         private static void ConfigureHiddenAssemblies()
         {
-#if NETCORE1_0 && !NET451
+#if (NETCORE1_0 || NETCORE2_0) && !NET451
             InternalLogger.Trace("Hide assemblies for callsite");
 
             SafeAddHiddenAssembly("Microsoft.Logging");
@@ -83,7 +83,7 @@ namespace NLog.Extensions.Logging
 #endif
         }
 
-#if NETCORE1_0 && !NET451
+#if (NETCORE1_0 || NETCORE2_0) && !NET451
         private static void SafeAddHiddenAssembly(string assemblyName, bool logOnException = true)
         {
             try


### PR DESCRIPTION
Fixed ConfigureHiddenAssemblies not working for .NET Core 2.0 Applications.
This solves issue: https://github.com/NLog/NLog/issues/2647
