### PR TITLE
Exclude NLog 5 prerelease version - V2

### DIFF
--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -51,7 +51,7 @@ For ASP.NET Core, use NLog.Web.AspNetCore: https://www.nuget.org/packages/NLog.W
     <Title>NLog.Extensions.Logging for NetStandard 2.0</Title>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="[4.5.4,5.0.0-0)" />
+    <PackageReference Include="NLog" Version="[4.5.4,5.0.0-beta01)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.2" />


### PR DESCRIPTION
trick 5.0.0-0 isn't accepted by nuget.org

fixes #216