### PR TITLE
BeginScope: support for non-serializable objects + performance improvement (20-50% cpu, 35% times less allocations)

### DIFF
--- a/examples/NetCore2/ConsoleExample/Program.cs
+++ b/examples/NetCore2/ConsoleExample/Program.cs
@@ -12,13 +12,14 @@ namespace ConsoleExample
             var logger = NLog.LogManager.LoadConfiguration("nlog.config").GetCurrentClassLogger();
             try
             {
-                var servicesProvider = BuildDi();
-                var runner = servicesProvider.GetRequiredService<Runner>();
+                using (var servicesProvider = BuildDi())
+                {
+                    var runner = servicesProvider.GetRequiredService<Runner>();
+                    runner.DoAction("Action1");
 
-                runner.DoAction("Action1");
-
-                Console.WriteLine("Press ANY key to exit");
-                Console.ReadLine();
+                    Console.WriteLine("Press ANY key to exit");
+                    Console.ReadLine();
+                }
             }
             catch (Exception ex)
             {
@@ -34,7 +35,7 @@ namespace ConsoleExample
         }
 
 
-        private static IServiceProvider BuildDi()
+        private static ServiceProvider BuildDi()
         {
             var services = new ServiceCollection();
 

--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -29,10 +29,7 @@ namespace NLog.Extensions.Logging
         /// <returns>ILoggerFactory for chaining</returns>
         public static ILoggerFactory AddNLog(this ILoggerFactory factory, NLogProviderOptions options)
         {
-            using (var provider = new NLogLoggerProvider(options))
-            {
-                factory.AddProvider(provider);
-            }
+            factory.AddProvider(new NLogLoggerProvider(options));
             return factory;
         }
 
@@ -55,10 +52,7 @@ namespace NLog.Extensions.Logging
         /// <returns>ILoggerFactory for chaining</returns>
         public static ILoggingBuilder AddNLog(this ILoggingBuilder factory, NLogProviderOptions options)
         {
-            using (var provider = new NLogLoggerProvider(options))
-            {
-                factory.AddProvider(provider);
-            }
+            factory.AddProvider(new NLogLoggerProvider(options));
             return factory;
         }
 #endif

--- a/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
@@ -54,7 +54,7 @@ namespace NLog.Extensions.Logging
                 if (state?.GetType().IsSerializable ?? true)
                     return NestedDiagnosticsLogicalContext.Push(state);
                 else
-                    return NestedDiagnosticsLogicalContext.Push(state.ToString());  // Support ViewComponentLogScope, ActionLogScope and others
+                    return NestedDiagnosticsLogicalContext.Push(state.ToString());  // Support HostingLogScope, ActionLogScope, FormattedLogValues and others
 #endif
             }
             catch (Exception ex)
@@ -80,6 +80,9 @@ namespace NLog.Extensions.Logging
                 for (int i = 0; i < messageProperties.Count; ++i)
                 {
                     var property = messageProperties[i];
+                    if (i == messageProperties.Count - 1 && i > 0 && property.Key == NLogLogger.OriginalFormatPropertyName)
+                        continue;   // Handle BeginScope("Hello {World}", "Earth")
+
                     scope.AddProperty(property.Key, property.Value);
                 }
 

--- a/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using NLog.Common;
+
+namespace NLog.Extensions.Logging
+{
+    /// <summary>
+    /// Converts Microsoft Extension Logging BeginScope into NLog NestedDiagnosticsLogicalContext + MappedDiagnosticsLogicalContext
+    /// </summary>
+    internal class NLogBeginScopeParser
+    {
+        private readonly NLogProviderOptions _options;
+        private readonly ConcurrentDictionary<Type, KeyValuePair<Func<object, object>, Func<object, object>>> _scopeStateExtractors = new ConcurrentDictionary<Type, KeyValuePair<Func<object, object>, Func<object, object>>>();
+
+        public NLogBeginScopeParser(NLogProviderOptions options)
+        {
+            _options = options ?? NLogProviderOptions.Default;
+        }
+
+        public IDisposable ParseBeginScope<T>(T state)
+        {
+            if (_options.CaptureMessageProperties)
+            {
+                if (state is IReadOnlyList<KeyValuePair<string, object>> contextProperties)
+                {
+                    return ScopeProperties.CreateFromState(contextProperties);
+                }
+
+                if (!(state is string))
+                {
+                    var scope = ScopeProperties.CreateFromStateExtractor(state, _scopeStateExtractors);
+                    if (scope != null)
+                        return scope;
+                }
+                else
+                {
+                    return NestedDiagnosticsLogicalContext.Push(state);
+                }
+            }
+
+            return CreateDiagnosticLogicalContext(state);
+        }
+
+        public static IDisposable CreateDiagnosticLogicalContext<T>(T state)
+        {
+            try
+            {
+#if NETSTANDARD
+                return NestedDiagnosticsLogicalContext.Push(state); // AsyncLocal has no requirement to be Serializable
+#else
+                // TODO Add support for Net46 in NLog (AsyncLocal), then we only have to do this check for legacy Net451 (CallContext)
+                if (state?.GetType().IsSerializable ?? true)
+                    return NestedDiagnosticsLogicalContext.Push(state);
+                else
+                    return NestedDiagnosticsLogicalContext.Push(state.ToString());  // Support ViewComponentLogScope, ActionLogScope and others
+#endif
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Debug(ex, "Exception in BeginScope push NestedDiagnosticsLogicalContext");
+                return null;
+            }
+        }
+
+        private class ScopeProperties : IDisposable
+        {
+            List<IDisposable> _properties;
+
+            /// <summary>
+            /// Properties, never null and lazy init
+            /// </summary>
+            List<IDisposable> Properties => _properties ?? (_properties = new List<IDisposable>());
+
+            public static ScopeProperties CreateFromState(IReadOnlyList<KeyValuePair<string, object>> messageProperties)
+            {
+                ScopeProperties scope = new ScopeProperties();
+
+                for (int i = 0; i < messageProperties.Count; ++i)
+                {
+                    var property = messageProperties[i];
+                    scope.AddProperty(property.Key, property.Value);
+                }
+
+                scope.AddDispose(CreateDiagnosticLogicalContext(messageProperties));
+                return scope;
+            }
+
+            public static bool TryCreateExtractor<T>(ConcurrentDictionary<Type, KeyValuePair<Func<object, object>, Func<object, object>>> stateExractor, T property, out KeyValuePair<Func<object, object>, Func<object, object>> keyValueExtractor)
+            {
+                Type propertyType = property.GetType();
+
+                if (!stateExractor.TryGetValue(propertyType, out keyValueExtractor))
+                {
+                    try
+                    {
+                        var itemType = propertyType.GetTypeInfo();
+                        if (!itemType.IsGenericType || itemType.GetGenericTypeDefinition() != typeof(KeyValuePair<,>))
+                            return false;
+
+                        var keyPropertyInfo = itemType.GetDeclaredProperty("Key");
+                        var valuePropertyInfo = itemType.GetDeclaredProperty("Value");
+                        if (valuePropertyInfo == null || keyPropertyInfo == null)
+                            return false;
+
+                        var keyValuePairObjParam = System.Linq.Expressions.Expression.Parameter(typeof(object), "pair");
+                        var keyValuePairTypeParam = System.Linq.Expressions.Expression.Convert(keyValuePairObjParam, propertyType);
+
+                        var propertyKeyAccess = System.Linq.Expressions.Expression.Property(keyValuePairTypeParam, keyPropertyInfo);
+                        var propertyKeyAccessObj = System.Linq.Expressions.Expression.Convert(propertyKeyAccess, typeof(object));
+                        var propertyKeyLambda = System.Linq.Expressions.Expression.Lambda<Func<object, object>>(propertyKeyAccessObj, keyValuePairObjParam).Compile();
+
+                        var propertyValueAccess = System.Linq.Expressions.Expression.Property(keyValuePairTypeParam, valuePropertyInfo);
+                        var propertyValueLambda = System.Linq.Expressions.Expression.Lambda<Func<object, object>>(propertyValueAccess, keyValuePairObjParam).Compile();
+
+                        keyValueExtractor = new KeyValuePair<Func<object, object>, Func<object, object>>(propertyKeyLambda, propertyValueLambda);
+                    }
+                    catch (Exception ex)
+                    {
+                        InternalLogger.Debug(ex, "Exception in BeginScope create property extractor");
+                    }
+                    finally
+                    {
+                        stateExractor[propertyType] = keyValueExtractor;
+                    }
+                }
+
+                return keyValueExtractor.Key != null;
+            }
+
+            public static IDisposable CreateFromStateExtractor<TState>(TState state, ConcurrentDictionary<Type, KeyValuePair<Func<object, object>, Func<object, object>>> stateExractor)
+            {
+                ScopeProperties scope = null;
+                var keyValueExtractor = default(KeyValuePair<Func<object, object>, Func<object, object>>);
+                if (state is System.Collections.IEnumerable messageProperties)
+                {
+                    foreach (var property in messageProperties)
+                    {
+                        if (property == null)
+                            return null;
+
+                        if (scope == null)
+                        {
+                            if (!TryCreateExtractor<object>(stateExractor, property, out keyValueExtractor))
+                                return null;
+
+                            scope = new ScopeProperties();
+                        }
+
+                        AddKeyValueProperty(scope, keyValueExtractor, property);
+                    }
+                }
+                else
+                {
+                    if (!TryCreateExtractor(stateExractor, state, out keyValueExtractor))
+                        return null;
+
+                    scope = new ScopeProperties();
+                    AddKeyValueProperty(scope, keyValueExtractor, state);
+                }
+
+                if (scope != null)
+                    scope.AddDispose(CreateDiagnosticLogicalContext(state));
+                return scope;
+            }
+
+            private static void AddKeyValueProperty(ScopeProperties scope, KeyValuePair<Func<object, object>, Func<object, object>> keyValueExtractor, object property)
+            {
+                try
+                {
+                    var propertyKey = keyValueExtractor.Key.Invoke(property);
+                    var propertyValue = keyValueExtractor.Value.Invoke(property);
+                    scope.AddProperty(propertyKey?.ToString() ?? string.Empty, propertyValue);
+                }
+                catch (Exception ex)
+                {
+                    InternalLogger.Debug(ex, "Exception in BeginScope add property");
+                }
+            }
+
+            public void AddDispose(IDisposable disposable)
+            {
+                if (disposable != null)
+                    Properties.Add(disposable);
+            }
+
+            public void AddProperty(string key, object value)
+            {
+                AddDispose(MappedDiagnosticsLogicalContext.SetScoped(key, value));
+            }
+
+            public void Dispose()
+            {
+                var properties = _properties;
+                if (properties != null)
+                {
+                    _properties = null;
+                    foreach (var property in properties)
+                    {
+                        try
+                        {
+                            property.Dispose();
+                        }
+                        catch (Exception ex)
+                        {
+                            InternalLogger.Debug(ex, "Exception in BeginScope dispose property {0}", property);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -13,20 +13,20 @@ namespace NLog.Extensions.Logging
     /// </summary>
     internal class NLogLogger : Microsoft.Extensions.Logging.ILogger
     {
-        private readonly ConcurrentDictionary<Type, KeyValuePair<Func<object, object>, Func<object, object>>> _scopeStateExtractors = new ConcurrentDictionary<Type, KeyValuePair<Func<object, object>, Func<object, object>>>();
-
         private readonly Logger _logger;
         private readonly NLogProviderOptions _options;
+        private readonly NLogBeginScopeParser _beginScopeParser;
 
         internal const string OriginalFormatPropertyName = "{OriginalFormat}";
         private static readonly object EmptyEventId = default(EventId);    // Cache boxing of empty EventId-struct
         private static readonly object ZeroEventId = default(EventId).Id;  // Cache boxing of zero EventId-Value
         private Tuple<string, string, string> _eventIdPropertyNames;
 
-        public NLogLogger(Logger logger, NLogProviderOptions options)
+        public NLogLogger(Logger logger, NLogProviderOptions options, NLogBeginScopeParser beginScopeParser)
         {
             _logger = logger;
             _options = options ?? NLogProviderOptions.Default;
+            _beginScopeParser = beginScopeParser;
         }
 
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
@@ -363,191 +363,6 @@ namespace NLog.Extensions.Logging
             }
         }
 
-        private class ScopeProperties : IDisposable
-        {
-            List<IDisposable> _properties;
-
-            /// <summary>
-            /// Properties, never null and lazy init
-            /// </summary>
-            List<IDisposable> Properties => _properties ?? (_properties = new List<IDisposable>());
-
-            public static ScopeProperties CreateFromState(IReadOnlyList<KeyValuePair<string, object>> messageProperties)
-            {
-                ScopeProperties scope = new ScopeProperties();
-
-                for (int i = 0; i < messageProperties.Count; ++i)
-                {
-                    var property = messageProperties[i];
-                    scope.AddProperty(property.Key, property.Value);
-                }
-
-                scope.AddDispose(CreateDiagnosticLogicalContext(messageProperties));
-                return scope;
-            }
-
-            public static IDisposable CreateDiagnosticLogicalContext<T>(T state)
-            {
-                try
-                {
-#if NETSTANDARD
-                    return NestedDiagnosticsLogicalContext.Push(state); // AsyncLocal has no requirement to be Serializable
-#else
-                    // TODO Add support for Net46 in NLog (AsyncLocal), then we only have to do this check for legacy Net451 (CallContext)
-                    if (state?.GetType().IsSerializable ?? true)
-                        return NestedDiagnosticsLogicalContext.Push(state);
-                    else
-                        return NestedDiagnosticsLogicalContext.Push(state.ToString());  // Support ViewComponentLogScope, ActionLogScope and others
-#endif
-                }
-                catch (Exception ex)
-                {
-                    InternalLogger.Debug(ex, "Exception in BeginScope push NestedDiagnosticsLogicalContext");
-                    return null;
-                }
-            }
-
-            public static bool TryCreateExtractor<T>(ConcurrentDictionary<Type, KeyValuePair<Func<object, object>, Func<object, object>>> stateExractor, T property, out KeyValuePair<Func<object, object>, Func<object, object>> keyValueExtractor)
-            {
-                Type propertyType = property.GetType();
-
-                if (!stateExractor.TryGetValue(propertyType, out keyValueExtractor))
-                {
-                    try
-                    {
-                        var itemType = propertyType.GetTypeInfo();
-                        if (!itemType.IsGenericType || itemType.GetGenericTypeDefinition() != typeof(KeyValuePair<,>))
-                            return false;
-
-                        var keyPropertyInfo = itemType.GetDeclaredProperty("Key");
-                        var valuePropertyInfo = itemType.GetDeclaredProperty("Value");
-                        if (valuePropertyInfo == null || keyPropertyInfo == null)
-                            return false;
-
-                        var keyValuePairObjParam = System.Linq.Expressions.Expression.Parameter(typeof(object), "pair");
-                        var keyValuePairTypeParam = System.Linq.Expressions.Expression.Convert(keyValuePairObjParam, propertyType);
-
-                        var propertyKeyAccess = System.Linq.Expressions.Expression.Property(keyValuePairTypeParam, keyPropertyInfo);
-                        var propertyKeyAccessObj = System.Linq.Expressions.Expression.Convert(propertyKeyAccess, typeof(object));
-                        var propertyKeyLambda = System.Linq.Expressions.Expression.Lambda<Func<object, object>>(propertyKeyAccessObj, keyValuePairObjParam).Compile();
-
-                        var propertyValueAccess = System.Linq.Expressions.Expression.Property(keyValuePairTypeParam, valuePropertyInfo);
-                        var propertyValueLambda = System.Linq.Expressions.Expression.Lambda<Func<object, object>>(propertyValueAccess, keyValuePairObjParam).Compile();
-
-                        keyValueExtractor = new KeyValuePair<Func<object, object>, Func<object, object>>(propertyKeyLambda, propertyValueLambda);
-                    }
-                    catch (Exception ex)
-                    {
-                        InternalLogger.Debug(ex, "Exception in BeginScope create property extractor");
-                    }
-                    finally
-                    {
-                        stateExractor[propertyType] = keyValueExtractor;
-                    }
-                }
-
-                return keyValueExtractor.Key != null;
-            }
-
-            public static IDisposable CreateFromStateExtractor<TState>(TState state, ConcurrentDictionary<Type, KeyValuePair<Func<object, object>, Func<object, object>>> stateExractor)
-            {
-                ScopeProperties scope = null;
-                var keyValueExtractor = default(KeyValuePair<Func<object, object>, Func<object, object>>);
-                if (state is System.Collections.IEnumerable messageProperties)
-                {
-                    foreach (var property in messageProperties)
-                    {
-                        if (property == null)
-                            return null;
-
-                        if (scope == null)
-                        {
-                            if (!TryCreateExtractor<object>(stateExractor, property, out keyValueExtractor))
-                                return null;
-
-                            scope = new ScopeProperties();
-                        }
-
-                        AddKeyValueProperty(scope, keyValueExtractor, property);
-                    }
-                }
-                else
-                {
-                    if (!TryCreateExtractor(stateExractor, state, out keyValueExtractor))
-                        return null;
-
-                    scope = new ScopeProperties();
-                    AddKeyValueProperty(scope, keyValueExtractor, state);
-                }
-
-                if (scope != null)
-                    scope.AddDispose(CreateDiagnosticLogicalContext(state));
-                return scope;
-            }
-
-            private static void AddKeyValueProperty(ScopeProperties scope, KeyValuePair<Func<object, object>, Func<object, object>> keyValueExtractor, object property)
-            {
-                try
-                {
-                    var propertyKey = keyValueExtractor.Key.Invoke(property);
-                    var propertyValue = keyValueExtractor.Value.Invoke(property);
-                    scope.AddProperty(propertyKey?.ToString() ?? string.Empty, propertyValue);
-                }
-                catch (Exception ex)
-                {
-                    InternalLogger.Debug(ex, "Exception in BeginScope add property");
-                }
-            }
-
-            public void AddDispose(IDisposable disposable)
-            {
-                if (disposable != null)
-                    Properties.Add(disposable);
-            }
-
-            public void AddProperty(string key, object value)
-            {
-                AddDispose(new ScopeProperty(key, value));
-            }
-
-            public void Dispose()
-            {
-                var properties = _properties;
-                if (properties != null)
-                {
-                    _properties = null;
-                    foreach (var property in properties)
-                    {
-                        try
-                        {
-                            property.Dispose();
-                        }
-                        catch (Exception ex)
-                        {
-                            InternalLogger.Debug(ex, "Exception in BeginScope dispose property {0}", property);
-                        }
-                    }
-                }
-            }
-
-            class ScopeProperty : IDisposable
-            {
-                string _key;
-
-                public ScopeProperty(string key, object value)
-                {
-                    _key = key;
-                    MappedDiagnosticsLogicalContext.Set(key, value);
-                }
-
-                public void Dispose()
-                {
-                    MappedDiagnosticsLogicalContext.Remove(_key);
-                }
-            }
-
-        }
-
         /// <summary>
         /// Begin a scope. Use in config with ${ndlc} 
         /// </summary>
@@ -560,26 +375,12 @@ namespace NLog.Extensions.Logging
                 throw new ArgumentNullException(nameof(state));
             }
 
-            if (_options.CaptureMessageProperties)
+            if (_beginScopeParser != null)
             {
-                if (state is IReadOnlyList<KeyValuePair<string, object>> contextProperties)
-                {
-                    return ScopeProperties.CreateFromState(contextProperties);
-                }
-
-                if (!(state is string))
-                {
-                    var scope = ScopeProperties.CreateFromStateExtractor(state, _scopeStateExtractors);
-                    if (scope != null)
-                        return scope;
-                }
-                else
-                {
-                    return NestedDiagnosticsLogicalContext.Push(state);
-                }
+                return _beginScopeParser.ParseBeginScope(state);
             }
 
-            return NestedDiagnosticsLogicalContext.Push(ScopeProperties.CreateDiagnosticLogicalContext(state));
+            return NLogBeginScopeParser.CreateDiagnosticLogicalContext(state);
         }
     }
 }

--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -370,6 +370,11 @@ namespace NLog.Extensions.Logging
         /// <returns></returns>
         public IDisposable BeginScope<TState>(TState state)
         {
+            if (!_options.IncludeScopes)
+            {
+                return NullScope.Instance;
+            }
+
             if (state == null)
             {
                 throw new ArgumentNullException(nameof(state));
@@ -381,6 +386,20 @@ namespace NLog.Extensions.Logging
             }
 
             return NLogBeginScopeParser.CreateDiagnosticLogicalContext(state);
+        }
+
+        private class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new NullScope();
+
+            private NullScope()
+            {
+            }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/src/NLog.Extensions.Logging/Logging/NLogLoggerFactory.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLoggerFactory.cs
@@ -9,7 +9,7 @@ namespace NLog.Extensions.Logging
     /// </summary>
     public class NLogLoggerFactory : ILoggerFactory
     {
-        private NLogLoggerProvider _provider;
+        private readonly NLogLoggerProvider _provider;
 
         /// <summary>
         /// New factory with default options

--- a/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
@@ -47,7 +47,9 @@ namespace NLog.Extensions.Logging
         /// <returns>New Logger</returns>
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string name)
         {
-            var beginScopeExtractor = (Options?.CaptureMessageProperties ?? true) ? (_beginScopeParser ?? System.Threading.Interlocked.CompareExchange(ref _beginScopeParser, new NLogBeginScopeParser(Options), null)) : null;
+            var beginScopeExtractor = ((Options?.CaptureMessageProperties ?? true) && (Options?.IncludeScopes ?? true))
+                ? (_beginScopeParser ?? System.Threading.Interlocked.CompareExchange(ref _beginScopeParser, new NLogBeginScopeParser(Options), null))
+                : null;
             return new NLogLogger(LogManager.GetLogger(name), Options, beginScopeExtractor);
         }
 

--- a/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
@@ -47,10 +47,10 @@ namespace NLog.Extensions.Logging
         /// <returns>New Logger</returns>
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string name)
         {
-            var beginScopeExtractor = ((Options?.CaptureMessageProperties ?? true) && (Options?.IncludeScopes ?? true))
+            var beginScopeParser = ((Options?.CaptureMessageProperties ?? true) && (Options?.IncludeScopes ?? true))
                 ? (_beginScopeParser ?? System.Threading.Interlocked.CompareExchange(ref _beginScopeParser, new NLogBeginScopeParser(Options), null))
                 : null;
-            return new NLogLogger(LogManager.GetLogger(name), Options, beginScopeExtractor);
+            return new NLogLogger(LogManager.GetLogger(name), Options, beginScopeParser);
         }
 
         /// <summary>

--- a/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
@@ -13,14 +13,14 @@ namespace NLog.Extensions.Logging
         private readonly IReadOnlyList<KeyValuePair<string, object>> _parameterList;
 
         public object OriginalMessage => _originalMessageIndex.HasValue ? _parameterList[_originalMessageIndex.Value].Value : null;
-        private int? _originalMessageIndex;
+        private readonly int? _originalMessageIndex;
 
         public bool HasComplexParameters => _hasMessageTemplateCapture || _isMixedPositional;
-        private bool _hasMessageTemplateCapture;
-        private bool _isMixedPositional;
+        private readonly bool _hasMessageTemplateCapture;
+        private readonly bool _isMixedPositional;
 
         public bool IsPositional => _isPositional;
-        private bool _isPositional;
+        private readonly bool _isPositional;
 
         public NLogMessageParameterList(IReadOnlyList<KeyValuePair<string, object>> parameterList)
         {

--- a/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
@@ -11,8 +11,10 @@ namespace NLog.Extensions.Logging
     internal class NLogMessageParameterList : IList<MessageTemplateParameter>
     {
         private readonly IReadOnlyList<KeyValuePair<string, object>> _parameterList;
+        private static readonly NLogMessageParameterList  EmptyList = new NLogMessageParameterList(new KeyValuePair<string, object>[0]);
+        private static readonly NLogMessageParameterList OriginalMessageList = new NLogMessageParameterList(new[] { new KeyValuePair<string, object>(NLogLogger.OriginalFormatPropertyName, string.Empty) });
 
-        public object OriginalMessage => _originalMessageIndex.HasValue ? _parameterList[_originalMessageIndex.Value].Value : null;
+        public bool HasOriginalMessage => _originalMessageIndex.HasValue;
         private readonly int? _originalMessageIndex;
 
         public bool HasComplexParameters => _hasMessageTemplateCapture || _isMixedPositional;
@@ -42,7 +44,32 @@ namespace NLog.Extensions.Logging
         /// </remarks>
         public static NLogMessageParameterList TryParse(IReadOnlyList<KeyValuePair<string, object>> parameterList)
         {
-            return parameterList?.Count > 0 ? new NLogMessageParameterList(parameterList) : null;
+            if (parameterList != null)
+            {
+                if (parameterList.Count > 1 || parameterList[0].Key != NLogLogger.OriginalFormatPropertyName)
+                {
+                    return new NLogMessageParameterList(parameterList);
+                }
+                else if (parameterList.Count == 1)
+                {
+                    return OriginalMessageList; // Skip allocation
+                }
+                else if (parameterList.Count == 0)
+                {
+                    return EmptyList;           // Skip allocation
+                }
+            }
+
+            return null;
+        }
+
+        public string GetOriginalMessage(IReadOnlyList<KeyValuePair<string, object>> messageProperties)
+        {
+            if (_originalMessageIndex < messageProperties?.Count)
+            {
+                return messageProperties[_originalMessageIndex.Value].Value as string;
+            }
+            return null;
         }
 
         /// <summary>

--- a/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
@@ -44,23 +44,23 @@ namespace NLog.Extensions.Logging
         /// </remarks>
         public static NLogMessageParameterList TryParse(IReadOnlyList<KeyValuePair<string, object>> parameterList)
         {
-            if (parameterList != null)
+            if (parameterList.Count > 1 || parameterList[0].Key != NLogLogger.OriginalFormatPropertyName)
             {
-                if (parameterList.Count > 1 || parameterList[0].Key != NLogLogger.OriginalFormatPropertyName)
-                {
-                    return new NLogMessageParameterList(parameterList);
-                }
-                else if (parameterList.Count == 1)
-                {
-                    return OriginalMessageList; // Skip allocation
-                }
-                else if (parameterList.Count == 0)
-                {
-                    return EmptyList;           // Skip allocation
-                }
+                return new NLogMessageParameterList(parameterList);
             }
+            else if (parameterList.Count == 1)
+            {
+                return OriginalMessageList; // Skip allocation
+            }
+            else
+            {
+                return EmptyList;           // Skip allocation
+            }
+        }
 
-            return null;
+        public bool HasMessageTemplateSyntax(bool parseMessageTemplates)
+        {
+            return HasOriginalMessage && (HasComplexParameters || (parseMessageTemplates && Count > 0));
         }
 
         public string GetOriginalMessage(IReadOnlyList<KeyValuePair<string, object>> messageProperties)

--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -48,6 +48,6 @@ namespace NLog.Extensions.Logging
         /// <summary>
         /// Default options
         /// </summary>
-        internal static NLogProviderOptions Default = new NLogProviderOptions();
+        internal static readonly NLogProviderOptions Default = new NLogProviderOptions();
     }
 }

--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -35,6 +35,11 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public bool ParseMessageTemplates { get; set; }
 
+        /// <summary>
+        /// Enable capture of scope information and inject into <see cref="NestedDiagnosticsLogicalContext" /> and <see cref="MappedDiagnosticsLogicalContext" />
+        /// </summary>
+        public bool IncludeScopes { get; set; }
+
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
         public NLogProviderOptions()
         {
@@ -43,6 +48,7 @@ namespace NLog.Extensions.Logging
             CaptureMessageTemplates = true;
             CaptureMessageProperties = true;
             ParseMessageTemplates = false;
+            IncludeScopes = true;
         }
 
         /// <summary>

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -42,15 +42,16 @@ For ASP.NET Core, use NLog.Web.AspNetCore: https://www.nuget.org/packages/NLog.W
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <Title>NLog.Extensions.Logging for NetStandard 1.3</Title>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <DefineConstants>$(DefineConstants);NETCORE1_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCORE1_0;NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <Title>NLog.Extensions.Logging for NetStandard 1.5</Title>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <DefineConstants>$(DefineConstants);NETCORE1_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCORE1_0;NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <Title>NLog.Extensions.Logging for NetStandard 2.0</Title>
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="[4.5.5,5.0.0-beta01)" />

--- a/test/CustomBeginScopeTest.cs
+++ b/test/CustomBeginScopeTest.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace NLog.Extensions.Logging.Tests
+{
+    public class CustomBeginScopeTest : NLogTestBase
+    {
+        [Fact]
+        public void TestCallSiteSayHello()
+        {
+            var runner = GetRunner<CustomBeginScopeTestRunner>();
+            var target = new NLog.Targets.MemoryTarget() { Layout = "${message} ${ndlc}" };
+            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            runner.SayHello();
+            Assert.Single(target.Logs);
+            Assert.Contains("Hello World", target.Logs[0]);
+        }
+
+
+        public class CustomBeginScopeTestRunner
+        {
+            private readonly ILogger<CustomBeginScopeTestRunner> _logger;
+
+            public CustomBeginScopeTestRunner(ILogger<CustomBeginScopeTestRunner> logger)
+            {
+                _logger = logger;
+            }
+
+            public void SayHello()
+            {
+                using (_logger.BeginScope(new ActionLogScope("World")))
+                {
+                    _logger.LogInformation("Hello");
+                }
+            }
+        }
+
+        private class ActionLogScope : IReadOnlyList<KeyValuePair<string, object>>
+        {
+            private readonly string _action;
+
+            public ActionLogScope(string action)
+            {
+                if (action == null)
+                {
+                    throw new ArgumentNullException(nameof(action));
+                }
+
+                _action = action;
+            }
+
+            public KeyValuePair<string, object> this[int index]
+            {
+                get
+                {
+                    if (index == 0)
+                    {
+                        return new KeyValuePair<string, object>("ActionId", _action);
+                    }
+                    throw new IndexOutOfRangeException(nameof(index));
+                }
+            }
+
+            public int Count => 1;
+
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+            {
+                for (var i = 0; i < Count; ++i)
+                {
+                    yield return this[i];
+                }
+            }
+
+            public override string ToString()
+            {
+                // We don't include the _action.Id here because it's just an opaque guid, and if
+                // you have text logging, you can already use the requestId for correlation.
+                return _action;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+    }
+}

--- a/test/CustomBeginScopeTest.cs
+++ b/test/CustomBeginScopeTest.cs
@@ -37,9 +37,10 @@ namespace NLog.Extensions.Logging.Tests
             var runner = GetRunner<CustomBeginScopeTestRunner>();
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message} ${mdlc:World}. Welcome ${ndlc}" };
             NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
-            runner.SayHi().Wait();
+            var scopeString = runner.SayHi().Result;
             Assert.Single(target.Logs);
             Assert.Equal("Hi Earth. Welcome Earth People", target.Logs[0]);
+            Assert.Equal("Earth People", scopeString);
         }
 
         public class CustomBeginScopeTestRunner
@@ -60,12 +61,13 @@ namespace NLog.Extensions.Logging.Tests
                 }
             }
 
-            public async Task SayHi()
+            public async Task<string> SayHi()
             {
-                using (_logger.BeginScope("{World} People", "Earth"))
+                using (var scopeState = _logger.BeginScope("{World} People", "Earth"))
                 {
                     await Task.Yield();
                     _logger.LogInformation("Hi");
+                    return scopeState.ToString();
                 }
             }
         }

--- a/test/CustomLoggerPropertyTest.cs
+++ b/test/CustomLoggerPropertyTest.cs
@@ -10,7 +10,7 @@ namespace NLog.Extensions.Logging.Tests
     public class CustomLoggerPropertyTest : NLogTestBase
     {
         [Fact]
-        public void TestExtraPropertySayHello()
+        public void TestExtraMessageTemplatePropertySayHello()
         {
             ConfigureServiceProvider<CustomLoggerPropertyTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
             var runner = GetRunner<CustomLoggerPropertyTestRunner>();
@@ -23,7 +23,7 @@ namespace NLog.Extensions.Logging.Tests
         }
 
         [Fact]
-        public void TestExtraPropertySayHigh5()
+        public void TestExtraMessageTemplatePropertySayHigh5()
         {
             ConfigureServiceProvider<CustomLoggerPropertyTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
             var runner = GetRunner<CustomLoggerPropertyTestRunner>();
@@ -33,6 +33,19 @@ namespace NLog.Extensions.Logging.Tests
             runner.SayHigh5();
             Assert.Single(target.Logs);
             Assert.Equal(@"Hi 5|ActivityId=42", target.Logs[0]);
+        }
+
+        [Fact]
+        public void TestExtraMessagePropertySayHi()
+        {
+            ConfigureServiceProvider<CustomLoggerPropertyTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)), new NLogProviderOptions() { CaptureMessageTemplates = false });
+            var runner = GetRunner<CustomLoggerPropertyTestRunner>();
+
+            var target = new NLog.Targets.MemoryTarget() { Layout = "${message}|${all-event-properties}" };
+            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            runner.SayHigh5();
+            Assert.Single(target.Logs);
+            Assert.Equal(@"Hi 5|ActivityId=42, 0=5", target.Logs[0]);
         }
 
         public class SameAssemblyLogger<T> : ILogger<T>
@@ -99,7 +112,7 @@ namespace NLog.Extensions.Logging.Tests
 
             public MyLogEvent<TState> AddProp<T>(string name, T value)
             {
-                _properties.Add(new KeyValuePair<string, object>(name, value));
+                _properties.Insert(0, new KeyValuePair<string, object>(name, value));
                 return this;
             }
 


### PR DESCRIPTION
Improves the support of custom objects together with BeginScope, when using AppDomains (Using CallContext that requires serializable objects)

Ex. ActionLogScope. Attempt to resolve https://github.com/NLog/NLog/issues/2812

Includes a small performance boost in handling of Microsofts internal `ActionLogScope` + `HostingLogScope` + `FormattedLogValue` by using IReadOnlyList in the fast-path of BeginScope. (Still supports Arrays and Lists), so it doesn't allocate yield-enumerator or uses keyvaluepair-property-extractor.

Includes a small performance boost by reusing a shared allocation of NLogBeginScopeParser (lives on the NLogLoggerProvider) for all NLogLogger-objects.

Includes a small performance boost in handling of log-message with no message-properties, by skipping allocation of message-property parser.

Includes a new IncludeScopes option (similar to the one for the Microsoft ConsoleLogger), that allows one to disable the overhead of the BeginScope handling (Skips parsing state and maintaining NDLC + MDLC)

Includes a small performance boost when using `CaptureMessageProperties = true`, but with `CaptureMessageTemplates = false`. Then it skips extra parsing of message properties to see if making use of message-template-syntax (or positional format args)

Improves the handling of `BeginScope("Hello {world}", "Earth")` so it only includes the actually property (and not the original beginscope-message-template).

Improves the behavior of `BeginScope` so the returned `IDisposable` has `ToString()` that returns input-state `ToString()`.