### PR TITLE
Fixing bug throwing ArgumentOutOfRangeException if input is empty list

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
@@ -44,7 +44,7 @@ namespace NLog.Extensions.Logging
         /// </remarks>
         public static NLogMessageParameterList TryParse(IReadOnlyList<KeyValuePair<string, object>> parameterList)
         {
-            if (parameterList.Count > 1 || parameterList[0].Key != NLogLogger.OriginalFormatPropertyName)
+            if (parameterList.Count > 1 || (parameterList.Count == 1 && parameterList[0].Key != NLogLogger.OriginalFormatPropertyName))
             {
                 return new NLogMessageParameterList(parameterList);
             }

--- a/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
@@ -58,5 +58,16 @@ namespace NLog.Extensions.Logging.Tests
             Assert.Equal(new MessageTemplateParameter("b", 2, null, CaptureType.Stringify), list[1]);
             Assert.Equal(new MessageTemplateParameter("c", 3, null, CaptureType.Serialize), list[2]);
         }
+        
+        [Fact]
+        public void TryParseShouldReturnEmptyListWhenInputIsEmpty()
+        {
+            var items = new List<KeyValuePair<string, object>>{};
+            NLogMessageParameterList parsedList = NLogMessageParameterList.TryParse(items);
+
+            var expectedCount = 0;
+            Assert.NotNull(parsedList);
+            Assert.Equal(expectedCount, parsedList.Count);
+        }
     }
 }


### PR DESCRIPTION
ref : System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection. Parameter name: index