### PR TITLE
NLogLoggingConfiguration - Fix leak in RegisterChangeCallback

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,9 @@
 
 Date format: (year/month/day)
 
+### v1.5.3 (2019/08/28)
+- [#322](https://github.com/NLog/NLog.Extensions.Logging/pull/322) Fixed memory leak in NLogLoggingConfiguration for autoreload
+
 ### v1.5.2 (2019/07/14)
 - [#314](https://github.com/NLog/NLog.Extensions.Logging/pull/314) Added NLogProviderOptions.ShutdownOnDispose (#314) (@304NotModified)
 - [#315](https://github.com/NLog/NLog.Extensions.Logging/pull/315) Update NLog to 4.6.5 (#315) (@304NotModified)

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@
 # creates NuGet package at \artifacts
 dotnet --version
 
-$versionPrefix = "1.5.2"
+$versionPrefix = "1.5.3"
 $versionSuffix = ""
 $versionFile = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
 $versionProduct = $versionPrefix;

--- a/src/NLog.Extensions.Hosting/NLog.Extensions.Hosting.csproj
+++ b/src/NLog.Extensions.Hosting/NLog.Extensions.Hosting.csproj
@@ -11,13 +11,15 @@
 
     <Company>NLog</Company>
     <Authors>Julian Verdurmen;Bryan Gonzalez</Authors>
-    <Description>NLog extension for Microsoft.Extensions.Hosting for usage in .NET Standard libraries and net core applications making use of the generic Host class introduced in netcore 2.1</Description>
+    <Description>NLog extension for Microsoft.Extensions.Hosting for logging in .NET Standard libraries and .NET Core applications using IHostBuilder.
+    
+For ASP.NET Core, use NLog.Web.AspNetCore: https://www.nuget.org/packages/NLog.Web.AspNetCore </Description>
     <PackageProjectUrl>https://github.com/NLog/NLog.Extensions.Logging</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/NLog/NLog.Extensions.Logging/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://nlog-project.org/NConfig.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/NLog/NLog.Extensions.Logging.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>NLog;Microsoft.Extensions.Hosting;log;logfiles;netcore</PackageTags>
+    <PackageTags>NLog;Microsoft.Extensions.Hosting;log;logging;logfiles;netcore</PackageTags>
     <PackageReleaseNotes>
 Full changelog: https://github.com/NLog/NLog.Extensions.Logging/blob/master/CHANGELOG.MD
     </PackageReleaseNotes>

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -12,15 +12,13 @@
     
     <Authors>Microsoft;Julian Verdurmen</Authors>
     <Company>NLog</Company>
-    <Description>NLog provider for Microsoft.Extensions.Logging for usage in .NET Standard libraries and console applicaties.
+    <Description>NLog LoggerProvider for Microsoft.Extensions.Logging for logging in .NET Standard libraries and .NET Core applications.
 
 For ASP.NET Core, use NLog.Web.AspNetCore: https://www.nuget.org/packages/NLog.Web.AspNetCore
     </Description>
-    <PackageTags>NLog;Microsoft.Extensions.Logging;log;logfiles;netcore</PackageTags>
+    <PackageTags>NLog;Microsoft.Extensions.Logging;log;logging;logfiles;netcore</PackageTags>
     <PackageReleaseNotes>
-
-- Added NLogProviderOptions.ShutdownOnDispose (#314) (@304NotModified)
-- Update NLog to 4.6.5 (#315) (@304NotModified)
+- Fixed memory leak in NLogLoggingConfiguration for autoreload #322 (@snakefoot)
 
 Full changelog: https://github.com/NLog/NLog.Extensions.Logging/blob/master/CHANGELOG.MD
     </PackageReleaseNotes>


### PR DESCRIPTION
See also: https://stackoverflow.com/questions/57485634/memory-leak-why-too-many-ichangetoken-objects