### PR TITLE
NLog.Extension.Logging.Tests - Stop using static LogManager

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogLoggerFactory.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLoggerFactory.cs
@@ -15,8 +15,8 @@ namespace NLog.Extensions.Logging
         /// New factory with default options
         /// </summary>
         public NLogLoggerFactory()
+            :this(new NLogLoggerProvider())
         {
-            _provider = new NLogLoggerProvider();
         }
 
         /// <summary>
@@ -24,8 +24,17 @@ namespace NLog.Extensions.Logging
         /// </summary>
         /// <param name="options"></param>
         public NLogLoggerFactory(NLogProviderOptions options)
+            :this(new NLogLoggerProvider(options))
         {
-            _provider = new NLogLoggerProvider(options);
+        }
+
+        /// <summary>
+        /// New factory with provider. 
+        /// </summary>
+        /// <param name="provider"></param>
+        public NLogLoggerFactory(NLogLoggerProvider provider)
+        {
+            _provider = provider;
         }
 
         /// <summary>
@@ -44,7 +53,7 @@ namespace NLog.Extensions.Logging
         {
             if (disposing)
             {
-                LogManager.Flush();
+                _provider.Dispose();
             }
         }
 

--- a/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
@@ -84,7 +84,7 @@ namespace NLog.Extensions.Logging
             {
                 if (Options.ShutdownOnDispose)
                 {
-                    LogManager.Shutdown();
+                    LogManager.Shutdown();  // TODO Fix global static. Instead use LogFactory-property
                 }
                 else
                 {

--- a/test/NLog.Extensions.Logging.Tests/CustomBeginScopeTest.cs
+++ b/test/NLog.Extensions.Logging.Tests/CustomBeginScopeTest.cs
@@ -14,7 +14,7 @@ namespace NLog.Extensions.Logging.Tests
         {
             var runner = GetRunner<CustomBeginScopeTestRunner>();
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message} ${mdlc:World}. Welcome ${ndlc}" };
-            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            ConfigureNLog(target);
             runner.SayHello().Wait();
             Assert.Single(target.Logs);
             Assert.Equal("Hello Earth. Welcome Earth People", target.Logs[0]);
@@ -25,7 +25,7 @@ namespace NLog.Extensions.Logging.Tests
         {
             var runner = GetRunner<CustomBeginScopeTestRunner>(new NLogProviderOptions() { IncludeScopes = false });
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message} ${mdlc:World}. Welcome ${ndlc}" };
-            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            ConfigureNLog(target);
             runner.SayHello().Wait();
             Assert.Single(target.Logs);
             Assert.Equal("Hello . Welcome ", target.Logs[0]);
@@ -36,7 +36,7 @@ namespace NLog.Extensions.Logging.Tests
         {
             var runner = GetRunner<CustomBeginScopeTestRunner>();
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message} ${mdlc:World}. Welcome ${ndlc}" };
-            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            ConfigureNLog(target);
             var scopeString = runner.SayHi().Result;
             Assert.Single(target.Logs);
             Assert.Equal("Hi Earth. Welcome Earth People", target.Logs[0]);
@@ -48,7 +48,7 @@ namespace NLog.Extensions.Logging.Tests
         {
             var runner = GetRunner<CustomBeginScopeTestRunner>();
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message}" };
-            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            ConfigureNLog(target);
             runner.SayNothing().Wait();
             Assert.Single(target.Logs);
             Assert.Equal("Nothing", target.Logs[0]);

--- a/test/NLog.Extensions.Logging.Tests/CustomLoggerCallSiteTest.cs
+++ b/test/NLog.Extensions.Logging.Tests/CustomLoggerCallSiteTest.cs
@@ -10,7 +10,7 @@ namespace NLog.Extensions.Logging.Tests
         [Fact]
         public void TestCallSiteSayHello()
         {
-            ConfigureServiceProvider<CustomLoggerCallSiteTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
+            ConfigureTransientService<CustomLoggerCallSiteTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
             var target = new NLog.Targets.MemoryTarget() { Layout = "${callsite}|${message}" };
             ConfigureNLog(target);
             var runner = GetRunner<CustomLoggerCallSiteTestRunner>();

--- a/test/NLog.Extensions.Logging.Tests/CustomLoggerCallSiteTest.cs
+++ b/test/NLog.Extensions.Logging.Tests/CustomLoggerCallSiteTest.cs
@@ -11,10 +11,10 @@ namespace NLog.Extensions.Logging.Tests
         public void TestCallSiteSayHello()
         {
             ConfigureServiceProvider<CustomLoggerCallSiteTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
+            var target = new NLog.Targets.MemoryTarget() { Layout = "${callsite}|${message}" };
+            ConfigureNLog(target);
             var runner = GetRunner<CustomLoggerCallSiteTestRunner>();
 
-            var target = new NLog.Targets.MemoryTarget() { Layout = "${callsite}|${message}" };
-            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
             runner.SayHello();
             Assert.Single(target.Logs);
             Assert.Contains("SayHello", target.Logs[0]);

--- a/test/NLog.Extensions.Logging.Tests/CustomLoggerPropertyTest.cs
+++ b/test/NLog.Extensions.Logging.Tests/CustomLoggerPropertyTest.cs
@@ -16,7 +16,7 @@ namespace NLog.Extensions.Logging.Tests
             var runner = GetRunner<CustomLoggerPropertyTestRunner>();
 
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message}|${all-event-properties}"};
-            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            ConfigureNLog(target);
             runner.SayHello();
             Assert.Single(target.Logs);
             Assert.Equal(@"Hello ""World""|userid=World, ActivityId=42", target.Logs[0]);
@@ -29,7 +29,7 @@ namespace NLog.Extensions.Logging.Tests
             var runner = GetRunner<CustomLoggerPropertyTestRunner>();
 
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message}|${all-event-properties}" };
-            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            ConfigureNLog(target);
             runner.SayHigh5();
             Assert.Single(target.Logs);
             Assert.Equal(@"Hi 5|ActivityId=42", target.Logs[0]);
@@ -42,7 +42,7 @@ namespace NLog.Extensions.Logging.Tests
             var runner = GetRunner<CustomLoggerPropertyTestRunner>();
 
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message}|${all-event-properties}" };
-            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+            ConfigureNLog(target);
             runner.SayHigh5();
             Assert.Single(target.Logs);
             Assert.Equal(@"Hi 5|ActivityId=42, 0=5", target.Logs[0]);

--- a/test/NLog.Extensions.Logging.Tests/CustomLoggerPropertyTest.cs
+++ b/test/NLog.Extensions.Logging.Tests/CustomLoggerPropertyTest.cs
@@ -12,7 +12,7 @@ namespace NLog.Extensions.Logging.Tests
         [Fact]
         public void TestExtraMessageTemplatePropertySayHello()
         {
-            ConfigureServiceProvider<CustomLoggerPropertyTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
+            ConfigureTransientService<CustomLoggerPropertyTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
             var runner = GetRunner<CustomLoggerPropertyTestRunner>();
 
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message}|${all-event-properties}"};
@@ -25,7 +25,7 @@ namespace NLog.Extensions.Logging.Tests
         [Fact]
         public void TestExtraMessageTemplatePropertySayHigh5()
         {
-            ConfigureServiceProvider<CustomLoggerPropertyTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
+            ConfigureTransientService<CustomLoggerPropertyTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)));
             var runner = GetRunner<CustomLoggerPropertyTestRunner>();
 
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message}|${all-event-properties}" };
@@ -38,7 +38,7 @@ namespace NLog.Extensions.Logging.Tests
         [Fact]
         public void TestExtraMessagePropertySayHi()
         {
-            ConfigureServiceProvider<CustomLoggerPropertyTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)), new NLogProviderOptions() { CaptureMessageTemplates = false });
+            ConfigureTransientService<CustomLoggerPropertyTestRunner>((s) => s.AddSingleton(typeof(ILogger<>), typeof(SameAssemblyLogger<>)), new NLogProviderOptions() { CaptureMessageTemplates = false });
             var runner = GetRunner<CustomLoggerPropertyTestRunner>();
 
             var target = new NLog.Targets.MemoryTarget() { Layout = "${message}|${all-event-properties}" };

--- a/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
@@ -229,7 +229,7 @@ namespace NLog.Extensions.Logging.Tests
 
         private Runner GetRunner()
         {
-            base.ConfigureServiceProvider<Runner>((s) => _nlogProvider.LogFactory.LoadConfiguration("nlog.config"));
+            base.ConfigureTransientService<Runner>((s) => _nlogProvider.LogFactory.LoadConfiguration("nlog.config"));
             return base.GetRunner<Runner>();
         }
 

--- a/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
@@ -221,15 +221,15 @@ namespace NLog.Extensions.Logging.Tests
             Assert.Equal(expectedLogMessage, target.Logs.FirstOrDefault());
         }
 
-        private static MemoryTarget GetTarget()
+        private MemoryTarget GetTarget()
         {
-            var target = LogManager.Configuration.FindTargetByName<MemoryTarget>("target1");
+            var target = _nlogProvider?.LogFactory?.Configuration?.FindTargetByName<MemoryTarget>("target1");
             return target;
         }
 
         private Runner GetRunner()
         {
-            base.ConfigureServiceProvider<Runner>((s) => LogManager.LoadConfiguration("nlog.config"));
+            base.ConfigureServiceProvider<Runner>((s) => _nlogProvider.LogFactory.LoadConfiguration("nlog.config"));
             return base.GetRunner<Runner>();
         }
 

--- a/test/NLog.Extensions.Logging.Tests/Logging/NLogLoggerFactoryTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Logging/NLogLoggerFactoryTests.cs
@@ -9,20 +9,16 @@ namespace NLog.Extensions.Logging.Tests.Logging
         public void Dispose_HappyPath_FlushLogFactory()
         {
             // Arrange
-            var logFactory = new LogFactory();
-            var logConfig = new NLog.Config.LoggingConfiguration(logFactory);
-            logConfig.AddTarget(new NLog.Targets.MemoryTarget("output"));
-            logConfig.AddRuleForAllLevels(new NLog.Targets.Wrappers.BufferingTargetWrapper("buffer", logConfig.FindTargetByName("output")));
-            logFactory.Configuration = logConfig;
-            var provider = new NLogLoggerProvider(null, logFactory);
-            var loggerFactory = new NLogLoggerFactory(provider);
+            ConfigureLoggerProvider();
+            ConfigureNLog(new NLog.Targets.Wrappers.BufferingTargetWrapper("buffer", new NLog.Targets.MemoryTarget("output")));
+            var loggerFactory = new NLogLoggerFactory(_nlogProvider);
 
             // Act
             loggerFactory.CreateLogger("test").LogInformation("Hello");
             loggerFactory.Dispose();
 
             // Assert
-            Assert.Single(logFactory.Configuration.FindTargetByName<NLog.Targets.MemoryTarget>("output").Logs);
+            Assert.Single(_nlogProvider.LogFactory.Configuration.FindTargetByName<NLog.Targets.MemoryTarget>("output").Logs);
         }
 
         [Fact]

--- a/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using NLog.MessageTemplates;
 using Xunit;
 

--- a/test/NLog.Extensions.Logging.Tests/NLogTestBase.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogTestBase.cs
@@ -9,14 +9,13 @@ namespace NLog.Extensions.Logging.Tests
         IServiceProvider _serviceProvider;
         protected NLogLoggerProvider _nlogProvider;
 
-        protected IServiceProvider ConfigureServiceProvider<T>(Action<ServiceCollection> configureServices = null, NLogProviderOptions options = null) where T : class
+        protected NLogLoggerProvider ConfigureLoggerProvider(NLogProviderOptions options = null, Action<ServiceCollection> configureServices = null)
         {
             if (_serviceProvider == null)
             {
                 var logFactory = new LogFactory();
                 _nlogProvider = new NLogLoggerProvider(options ?? new NLogProviderOptions() { CaptureMessageTemplates = true, CaptureMessageProperties = true }, logFactory);
                 var services = new ServiceCollection();
-                services.AddTransient<T>();
                 services.AddSingleton<ILoggerFactory, LoggerFactory>();
                 services.AddSingleton(typeof(ILogger<>), typeof(Logger<>));
                 configureServices?.Invoke(services);
@@ -24,6 +23,13 @@ namespace NLog.Extensions.Logging.Tests
                 var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
                 loggerFactory.AddProvider(_nlogProvider);
             }
+            return _nlogProvider;
+        }
+
+        protected IServiceProvider ConfigureTransientService<T>(Action<ServiceCollection> configureServices = null, NLogProviderOptions options = null) where T : class
+        {
+            if (_serviceProvider == null)
+                ConfigureLoggerProvider(options, s => { s.AddTransient<T>(); configureServices?.Invoke(s); });
             return _serviceProvider;
         }
 
@@ -32,13 +38,15 @@ namespace NLog.Extensions.Logging.Tests
             nlogTarget = nlogTarget ?? new NLog.Targets.MemoryTarget("output") { Layout = "${message}" };
             var nlogConfig = new NLog.Config.LoggingConfiguration(_nlogProvider.LogFactory);
             nlogConfig.AddRuleForAllLevels(nlogTarget);
+            if (nlogTarget is NLog.Targets.Wrappers.WrapperTargetBase wrapperTarget)
+                nlogConfig.AddTarget(wrapperTarget.WrappedTarget);
             _nlogProvider.LogFactory.Configuration = nlogConfig;
         }
 
         protected T GetRunner<T>(NLogProviderOptions options = null) where T : class
         {
             // Start program
-            var runner = ConfigureServiceProvider<T>(null, options).GetRequiredService<T>();
+            var runner = ConfigureTransientService<T>(null, options).GetRequiredService<T>();
             return runner;
         }
     }

--- a/test/NLog.Extensions.Logging.Tests/NLogTestBase.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogTestBase.cs
@@ -1,41 +1,38 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using NLog.Common;
 
 namespace NLog.Extensions.Logging.Tests
 {
     public class NLogTestBase
     {
         IServiceProvider _serviceProvider;
-
-        /// <summary>
-        /// Don't run tests with internal log in parallel
-        ///
-        /// usage:  [Collection(TestsWithInternalLog)]
-        /// </summary>
-        public const string TestsWithInternalLog = "Test-with-internal-log";
+        protected NLogLoggerProvider _nlogProvider;
 
         protected IServiceProvider ConfigureServiceProvider<T>(Action<ServiceCollection> configureServices = null, NLogProviderOptions options = null) where T : class
         {
             if (_serviceProvider == null)
             {
+                var logFactory = new LogFactory();
+                _nlogProvider = new NLogLoggerProvider(options ?? new NLogProviderOptions() { CaptureMessageTemplates = true, CaptureMessageProperties = true }, logFactory);
                 var services = new ServiceCollection();
-
                 services.AddTransient<T>();
                 services.AddSingleton<ILoggerFactory, LoggerFactory>();
                 services.AddSingleton(typeof(ILogger<>), typeof(Logger<>));
                 configureServices?.Invoke(services);
-
                 _serviceProvider = services.BuildServiceProvider();
-
                 var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
-                loggerFactory.AddNLog(options ?? new NLogProviderOptions() { CaptureMessageTemplates = true, CaptureMessageProperties = true });
+                loggerFactory.AddProvider(_nlogProvider);
             }
             return _serviceProvider;
+        }
+
+        protected void ConfigureNLog(NLog.Targets.Target nlogTarget = null)
+        {
+            nlogTarget = nlogTarget ?? new NLog.Targets.MemoryTarget("output") { Layout = "${message}" };
+            var nlogConfig = new NLog.Config.LoggingConfiguration(_nlogProvider.LogFactory);
+            nlogConfig.AddRuleForAllLevels(nlogTarget);
+            _nlogProvider.LogFactory.Configuration = nlogConfig;
         }
 
         protected T GetRunner<T>(NLogProviderOptions options = null) where T : class
@@ -43,26 +40,6 @@ namespace NLog.Extensions.Logging.Tests
             // Start program
             var runner = ConfigureServiceProvider<T>(null, options).GetRequiredService<T>();
             return runner;
-        }
-
-        /// <summary>
-        /// Capture internal log.
-        ///
-        /// Important: mark test class with  [Collection(TestsWithInternalLog)]
-        /// </summary>
-        /// <returns></returns>
-        protected static StringWriter CaptureInternalLog()
-        {
-            var stringWriter = new StringWriter();
-            InternalLogger.LogLevel = LogLevel.Trace;
-            InternalLogger.LogWriter = stringWriter;
-            return stringWriter;
-        }
-
-        ~NLogTestBase()
-        {
-            InternalLogger.LogLevel = LogLevel.Off;
-            InternalLogger.LogWriter = null;
         }
     }
 }


### PR DESCRIPTION
Trying to resolve #326 by cleaning up tests that depend on LogManager and InternalLogger.