### PR TITLE
NLogMessageParameterList - Reduce code complexity for IsValidParameterList

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
@@ -94,13 +94,13 @@ namespace NLog.Extensions.Logging
             {
                 object scopeObject = scopePropertyList;
 
-                if (scopePropertyList.Count > 0 && scopePropertyList[scopePropertyList.Count - 1].Key == NLogLogger.OriginalFormatPropertyName)
+                if (scopePropertyList.Count > 0 && NLogLogger.OriginalFormatPropertyName.Equals(scopePropertyList[scopePropertyList.Count - 1].Key))
                 {
                     var propertyList = new List<KeyValuePair<string, object>>(scopePropertyList.Count - 1);
                     for (var i = 0; i < scopePropertyList.Count; ++i)
                     {
                         var property = scopePropertyList[i];
-                        if (i == scopePropertyList.Count - 1 && i > 0 && property.Key == NLogLogger.OriginalFormatPropertyName)
+                        if (i == scopePropertyList.Count - 1 && i > 0 && NLogLogger.OriginalFormatPropertyName.Equals(property.Key))
                         {
                             continue; // Handle BeginScope("Hello {World}", "Earth")
                         }

--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -376,7 +376,7 @@ namespace NLog.Extensions.Logging
                 if (String.IsNullOrEmpty(property.Key))
                     continue;
 
-                if (i == messageProperties.Count - 1 && property.Key == OriginalFormatPropertyName)
+                if (i == messageProperties.Count - 1 && OriginalFormatPropertyName.Equals(property.Key))
                     continue;
 
                 eventInfo.Properties[property.Key] = property.Value;

--- a/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
@@ -14,7 +14,8 @@ namespace NLog.Extensions.Logging.Tests
             {
                 new KeyValuePair<string, object>("", 1),
                 new KeyValuePair<string, object>("a", 2),
-                new KeyValuePair<string, object>("b", 3)
+                new KeyValuePair<string, object>("b", 3),
+                new KeyValuePair<string, object>("{OriginalFormat}", "{0}{1}{2}"),
             };
             var list = new NLogMessageParameterList(items);
 


### PR DESCRIPTION
And micro-optimization for comparison against OriginalFormatPropertyName (skip null-check by using Equals for OriginalFormatPropertyName-object)