### PR TITLE
ILoggerFactory is obsolete in .NET Core 3. Instead use ILoggingBuilder.AddNLog

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,10 @@
 
 Date format: (year/month/day)
 
+### v1.6.0 (2019/09/24)
+- [#342](https://github.com/NLog/NLog.Extensions.Logging/pull/342) ILoggerFactory is obsolete in NetCore3. Instead use ILoggingBuilder.AddNLog
+- [#333](https://github.com/NLog/NLog.Extensions.Logging/pull/333) + [#334](https://github.com/NLog/NLog.Extensions.Logging/pull/334) Minor optimization in parsing of LogEvent property-names
+
 ### v1.5.4 (2019/09/06)
 - [#325](https://github.com/NLog/NLog.Extensions.Logging/pull/325) Fix dispose for AddNLog (on ILoggingBuilder) and no double logging when also using UseNLog (@snakefoot)
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,7 +3,7 @@
 Date format: (year/month/day)
 
 ### v1.6.0 (2019/09/24)
-- [#342](https://github.com/NLog/NLog.Extensions.Logging/pull/342) ILoggerFactory is obsolete in NetCore3. Instead use ILoggingBuilder.AddNLog
+- [#342](https://github.com/NLog/NLog.Extensions.Logging/pull/342) ILoggerFactory is obsolete in .NET Core 3. Instead use ILoggingBuilder.AddNLog
 - [#333](https://github.com/NLog/NLog.Extensions.Logging/pull/333) + [#334](https://github.com/NLog/NLog.Extensions.Logging/pull/334) Minor optimization in parsing of LogEvent property-names
 
 ### v1.5.4 (2019/09/06)

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@
 # creates NuGet package at \artifacts
 dotnet --version
 
-$versionPrefix = "1.5.4"
+$versionPrefix = "1.6.0"
 $versionSuffix = ""
 $versionFile = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
 $versionProduct = $versionPrefix;

--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -22,6 +22,9 @@ namespace NLog.Extensions.Logging
         /// </summary>
         /// <param name="factory"></param>
         /// <returns>ILoggerFactory for chaining</returns>
+#if !NETCORE1_0
+        [Obsolete("Instead use ILoggingBuilder.AddNLog() or IHostBuilder.UseNLog()")]
+#endif
         public static ILoggerFactory AddNLog(this ILoggerFactory factory)
         {
             return factory.AddNLog(NLogProviderOptions.Default);
@@ -33,6 +36,9 @@ namespace NLog.Extensions.Logging
         /// <param name="factory"></param>
         /// <param name="options">NLog options</param>
         /// <returns>ILoggerFactory for chaining</returns>
+#if !NETCORE1_0
+        [Obsolete("Instead use ILoggingBuilder.AddNLog() or IHostBuilder.UseNLog()")]
+#endif
         public static ILoggerFactory AddNLog(this ILoggerFactory factory, NLogProviderOptions options)
         {
             factory.AddProvider(new NLogLoggerProvider(options));
@@ -45,6 +51,9 @@ namespace NLog.Extensions.Logging
         /// <param name="factory"></param>
         /// <param name="configuration"></param>
         /// <returns>ILoggerFactory for chaining</returns>
+#if !NETCORE1_0
+        [Obsolete("Instead use ILoggingBuilder.AddNLog() or IHostBuilder.UseNLog()")]
+#endif
         public static ILoggerFactory AddNLog(this ILoggerFactory factory, IConfiguration configuration)
         {
             var provider = CreateNLogProvider(configuration);

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -18,7 +18,8 @@ For ASP.NET Core, use NLog.Web.AspNetCore: https://www.nuget.org/packages/NLog.W
     </Description>
     <PackageTags>NLog;Microsoft.Extensions.Logging;log;logging;logfiles;netcore</PackageTags>
     <PackageReleaseNotes>
-- Fix dispose for AddNLog (on ILoggingBuilder) and no double logging when also using UseNLog (@snakefoot)
+- Marked ILoggerFactory extension methods as obsolete, since obsolete in NetCore3
+- Minor optimization in parsing of LogEvent property-names
 
 Full changelog: https://github.com/NLog/NLog.Extensions.Logging/blob/master/CHANGELOG.MD
     </PackageReleaseNotes>

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -20,6 +20,7 @@ For ASP.NET Core, use NLog.Web.AspNetCore: https://www.nuget.org/packages/NLog.W
     <PackageReleaseNotes>
 - Marked ILoggerFactory extension methods as obsolete, since obsolete in NetCore3
 - Minor optimization in parsing of LogEvent property-names
+- Updated NLog dependency
 
 Full changelog: https://github.com/NLog/NLog.Extensions.Logging/blob/master/CHANGELOG.MD
     </PackageReleaseNotes>
@@ -59,7 +60,7 @@ Full changelog: https://github.com/NLog/NLog.Extensions.Logging/blob/master/CHAN
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="[4.6.5,5.0.0-beta01)" />
+    <PackageReference Include="NLog" Version="[4.6.7,5.0.0-beta01)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.0" />

--- a/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
@@ -12,6 +12,7 @@ namespace NLog.Extensions.Logging.Tests.Extensions
     public class ConfigureExtensionsTests
     {
         [Fact]
+        [Obsolete("Instead use ILoggingBuilder.AddNLog() or IHostBuilder.UseNLog()")]
         public void AddNLog_LoggerFactory_LogInfo_ShouldLogToNLog()
         {
             // Arrange
@@ -32,6 +33,7 @@ namespace NLog.Extensions.Logging.Tests.Extensions
         [InlineData("EventId", "eventId2")]
         [InlineData("EventId_Name", "eventId2")]
         [InlineData("EventId_Id", "2")]
+        [Obsolete("Instead use ILoggingBuilder.AddNLog() or IHostBuilder.UseNLog()")]
         public void AddNLog_LoggerFactory_LogInfoWithEventId_ShouldLogToNLogWithEventId(string eventPropery, string expectedEventInLog)
         {
             // Arrange


### PR DESCRIPTION
or IHostBuilder.UseNLog()