### PR TITLE
Introduce AddNLog with NLog-config parameter

### DIFF
--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -97,6 +97,32 @@ namespace NLog.Extensions.Logging
             factory.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, NLogLoggerProvider>(s => new NLogLoggerProvider(options)));
             return factory;
         }
+
+        /// <summary>
+        /// Enable NLog as logging provider for Microsoft Extension Logging
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="config">New NLog config.</param>
+        /// <returns></returns>
+        public static ILoggingBuilder AddNLog(this ILoggingBuilder builder, LoggingConfiguration config)
+        {
+            builder.AddNLog();
+            LogManager.Configuration = config;
+            return builder;
+        }
+
+        /// <summary>
+        /// Enable NLog as logging provider for Microsoft Extension Logging
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configFileRelativePath">relative path to NLog configuration file.</param>
+        /// <returns></returns>
+        public static ILoggingBuilder AddNLog(this ILoggingBuilder builder, string configFileRelativePath)
+        {
+            builder.AddNLog();
+            LogManager.LoadConfiguration(configFileRelativePath);
+            return builder;
+        }
 #endif
 
         /// <summary>

--- a/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
@@ -60,7 +60,6 @@ namespace NLog.Extensions.Logging.Tests.Extensions
             var config = CreateConfigWithMemoryTarget(out var memoryTarget);
 
             // Act
-            builder.AddNLog();
             builder.AddNLog(config);
             var provider = GetLoggerProvider(builder);
             var logger = provider.CreateLogger("logger1");

--- a/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
@@ -61,7 +61,7 @@ namespace NLog.Extensions.Logging.Tests.Extensions
 
             // Act
             builder.AddNLog();
-            LogManager.Configuration = config;
+            builder.AddNLog(config);
             var provider = GetLoggerProvider(builder);
             var logger = provider.CreateLogger("logger1");
 
@@ -84,7 +84,7 @@ namespace NLog.Extensions.Logging.Tests.Extensions
             public IServiceCollection Services { get; set; } = new ServiceCollection();
         }
 #endif
-        
+
         private static void AssertSingleMessage(MemoryTarget memoryTarget, string expectedMessage)
         {
             Assert.Equal(1, memoryTarget.Logs.Count);


### PR DESCRIPTION
Will also allow AddNLog to automatically register `ConfigSettingLayoutRenderer.DefaultConfiguration` by extracting `IConfiguration` from `ServiceProvider` (When not provided directly)