### PR TITLE
AddNLog overload with NLogProviderOptions and LoggingConfiguration

### DIFF
--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -104,17 +104,17 @@ namespace NLog.Extensions.Logging
         /// <returns>ILoggingBuilder for chaining</returns>
         public static ILoggingBuilder AddNLog(this ILoggingBuilder builder, LoggingConfiguration configuration)
         {
-            return AddNLog(builder, null, configuration);
+            return AddNLog(builder, configuration, null);
         }
 
         /// <summary>
         /// Enable NLog as logging provider for Microsoft Extension Logging
         /// </summary>
         /// <param name="builder"></param>
-        /// <param name="options">NLog options</param>
         /// <param name="configuration">New NLog config.</param>
+        /// <param name="options">NLog options</param>
         /// <returns>ILoggingBuilder for chaining</returns>
-        public static ILoggingBuilder AddNLog(this ILoggingBuilder builder, NLogProviderOptions options, LoggingConfiguration configuration)
+        public static ILoggingBuilder AddNLog(this ILoggingBuilder builder, LoggingConfiguration configuration, NLogProviderOptions options)
         {
             AddNLogLoggerProvider(builder.Services, null, options, (serviceProvider, config, options) =>
             {

--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -104,7 +104,19 @@ namespace NLog.Extensions.Logging
         /// <returns>ILoggingBuilder for chaining</returns>
         public static ILoggingBuilder AddNLog(this ILoggingBuilder builder, LoggingConfiguration configuration)
         {
-            AddNLogLoggerProvider(builder.Services, null, null, (serviceProvider, config, options) =>
+            return AddNLog(builder, null, configuration);
+        }
+
+        /// <summary>
+        /// Enable NLog as logging provider for Microsoft Extension Logging
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="options">NLog options</param>
+        /// <param name="configuration">New NLog config.</param>
+        /// <returns>ILoggingBuilder for chaining</returns>
+        public static ILoggingBuilder AddNLog(this ILoggingBuilder builder, NLogProviderOptions options, LoggingConfiguration configuration)
+        {
+            AddNLogLoggerProvider(builder.Services, null, options, (serviceProvider, config, options) =>
             {
                 var provider = CreateNLogLoggerProvider(serviceProvider, config, options);
                 // Delay initialization of targets until we have loaded config-settings

--- a/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
@@ -69,6 +69,27 @@ namespace NLog.Extensions.Logging.Tests.Extensions
             AssertSingleMessage(memoryTarget, "Info|test message with 1 arg");
         }
 
+        [Theory]
+        [InlineData("EventId", "eventId2")]
+        [InlineData("EventId_Name", "eventId2")]
+        [InlineData("EventId_Id", "2")]
+        public void AddNLog_LoggingBuilder_LogInfoWithEventId_ShouldLogToNLogWithEventId(string eventPropery, string expectedEventInLog)
+        {
+            // Arrange
+            ILoggingBuilder builder = new LoggingBuilderStub();
+            var options = new NLogProviderOptions { EventIdSeparator = "_" };
+            var config = CreateConfigWithMemoryTarget(out var memoryTarget, $"${{event-properties:{eventPropery}}} - ${{message}}");
+
+            // Act
+            builder.AddNLog(options, config);
+            var provider = GetLoggerProvider(builder);
+            var logger = provider.CreateLogger("logger1");
+            logger.LogInformation(new EventId(2, "eventId2"), "test message with {0} arg", 1);
+
+            // Assert
+            AssertSingleMessage(memoryTarget, $"{expectedEventInLog} - test message with 1 arg");
+        }
+
         [Fact]
         public void AddNLog_LogFactoryBuilder_LogInfo_ShouldLogToNLog()
         {

--- a/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
@@ -77,11 +77,11 @@ namespace NLog.Extensions.Logging.Tests.Extensions
         {
             // Arrange
             ILoggingBuilder builder = new LoggingBuilderStub();
-            var options = new NLogProviderOptions { EventIdSeparator = "_" };
             var config = CreateConfigWithMemoryTarget(out var memoryTarget, $"${{event-properties:{eventPropery}}} - ${{message}}");
+            var options = new NLogProviderOptions { EventIdSeparator = "_" };
 
             // Act
-            builder.AddNLog(options, config);
+            builder.AddNLog(config, options);
             var provider = GetLoggerProvider(builder);
             var logger = provider.CreateLogger("logger1");
             logger.LogInformation(new EventId(2, "eventId2"), "test message with {0} arg", 1);


### PR DESCRIPTION
Resolves #391

Added overload of `AddNLog` to accept both `NLogProviderOptions` and `LoggingConfiguration` and corresponding test.