### PR TITLE
Introduced SetupExtensionLogging extension method for LogFactory.Setup

### DIFF
--- a/examples/NetCore2/ConsoleExampleJsonConfig/Program.cs
+++ b/examples/NetCore2/ConsoleExampleJsonConfig/Program.cs
@@ -20,7 +20,9 @@ namespace ConsoleExample
                     .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                     .Build();
 
-                LogManager.Configuration = new NLogLoggingConfiguration(config.GetSection("NLog"));
+                LogManager.Setup()
+                    .SetupExtensions(s => s.AutoLoadAssemblies(false))
+                    .SetupExtensionLogging(s => s.LoadNLogLoggingConfiguration(config));
 
                 var servicesProvider = BuildDi(config);
                 using (servicesProvider as IDisposable)

--- a/src/NLog.Extensions.Logging/Config/ISetupLoggerProviderBuilder.cs
+++ b/src/NLog.Extensions.Logging/Config/ISetupLoggerProviderBuilder.cs
@@ -1,0 +1,13 @@
+﻿namespace NLog.Extensions.Logging
+{
+    /// <summary>
+    /// Interface for fluent setup of LogFactory integration with Microsoft Extension Logging
+    /// </summary>
+    public interface ISetupExtensionLoggingBuilder
+    {
+        /// <summary>
+        /// LogFactory under configuration
+        /// </summary>
+        LogFactory LogFactory { get; }
+    }
+}

--- a/src/NLog.Extensions.Logging/Config/SetupBuilderExtensions.cs
+++ b/src/NLog.Extensions.Logging/Config/SetupBuilderExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using NLog.Config;
+
+namespace NLog.Extensions.Logging
+{
+    /// <summary>
+    /// Extension methods to setup LogFactory options
+    /// </summary>
+    public static class SetupBuilderExtensions
+    {
+        /// <summary>
+        /// Setup of LogFactory integration with Microsoft Extension Logging
+        /// </summary>
+        public static ISetupBuilder SetupExtensionLogging(this ISetupBuilder setupBuilder, Action<ISetupExtensionLoggingBuilder> extensionsBuilder)
+        {
+            extensionsBuilder(new SetupExtensionLoggingBuilder(setupBuilder.LogFactory));
+            return setupBuilder;
+        }
+
+        private class SetupExtensionLoggingBuilder : ISetupExtensionLoggingBuilder
+        {
+            public SetupExtensionLoggingBuilder(LogFactory logFactory)
+            {
+                LogFactory = logFactory;
+            }
+
+            public LogFactory LogFactory { get; }
+        }
+    }
+}

--- a/src/NLog.Extensions.Logging/Config/SetupLoggerProviderBuilderExtensions.cs
+++ b/src/NLog.Extensions.Logging/Config/SetupLoggerProviderBuilderExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Reflection;
+
+namespace NLog.Extensions.Logging
+{
+    /// <summary>
+    /// Extension methods to setup NLog together with Microsoft Extension Logging
+    /// </summary>
+    public static class SetupLoggerProviderBuilderExtensions
+    {
+        /// <summary>
+        /// Enables lookup of settings from appsettings.json using ${configsetting}
+        /// </summary>
+        public static ISetupExtensionLoggingBuilder SetupConfigSettings(this ISetupExtensionLoggingBuilder setupBuilder, Microsoft.Extensions.Configuration.IConfiguration configuration)
+        {
+            ConfigSettingLayoutRenderer.DefaultConfiguration = configuration;
+            NLog.Config.ConfigurationItemFactory.Default.RegisterType(typeof(ConfigSettingLayoutRenderer), string.Empty);
+            return setupBuilder;
+        }
+
+        /// <summary>
+        /// Loads NLog LoggingConfiguration from appsettings.json from NLog-section
+        /// </summary>
+        public static ISetupExtensionLoggingBuilder LoadNLogLoggingConfiguration(this ISetupExtensionLoggingBuilder setupBuilder, Microsoft.Extensions.Configuration.IConfiguration configuration)
+        {
+            SetupConfigSettings(setupBuilder, configuration);
+            setupBuilder.LogFactory.Configuration = new NLogLoggingConfiguration(configuration.GetSection("NLog"), setupBuilder.LogFactory);
+            return setupBuilder;
+        }
+    }
+}

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -65,7 +65,7 @@ Full changelog: https://github.com/NLog/NLog.Extensions.Logging/blob/master/CHAN
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="[4.6.8,5.0.0-beta01)" />
+    <PackageReference Include="NLog" Version="4.7.0-rc1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.0" />

--- a/test/NLog.Extensions.Logging.Tests/NLogLoggingConfigurationTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogLoggingConfigurationTests.cs
@@ -129,7 +129,7 @@ namespace NLog.Extensions.Logging.Tests
         }
 
         [Fact]
-        private void ReloadLogFactoryConfiguration()
+        public void ReloadLogFactoryConfiguration()
         {
             var memoryConfig = CreateMemoryConfigConsoleTargetAndRule();
             memoryConfig["NLog:Targets:file:type"] = "File";
@@ -151,7 +151,7 @@ namespace NLog.Extensions.Logging.Tests
         }
 
         [Fact]
-        private void ReloadLogFactoryConfigurationKeepVariables()
+        public void ReloadLogFactoryConfigurationKeepVariables()
         {
             var memoryConfig = CreateMemoryConfigConsoleTargetAndRule();
             memoryConfig["NLog:Targets:file:type"] = "File";
@@ -168,6 +168,23 @@ namespace NLog.Extensions.Logging.Tests
             Assert.Equal("updated.txt", (logFactory.Configuration.FindTargetByName("file") as FileTarget)?.FileName.Render(LogEventInfo.CreateNullEvent()));
             configuration.Reload(); // Automatic Reload
             Assert.Equal("updated.txt", (logFactory.Configuration.FindTargetByName("file") as FileTarget)?.FileName.Render(LogEventInfo.CreateNullEvent()));
+        }
+
+        [Fact]
+        public void SetupBuilderNLogLoggingConfiguration()
+        {
+            var memoryConfig = CreateMemoryConfigConsoleTargetAndRule();
+            memoryConfig["NLog:Targets:file:type"] = "File";
+            memoryConfig["NLog:Targets:file:fileName"] = "hello.txt";
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(memoryConfig).Build();
+
+            var logFactory = new LogFactory();
+            logFactory.Setup()
+                .SetupExtensions(s => s.AutoLoadAssemblies(false))
+                .SetupExtensionLogging(s => s.LoadNLogLoggingConfiguration(configuration));
+
+            Assert.Single(logFactory.Configuration.LoggingRules);
+            Assert.Equal(2, logFactory.Configuration.LoggingRules[0].Targets.Count);
         }
 
         private static NLogLoggingConfiguration CreateNLogLoggingConfigurationWithNLogSection(IDictionary<string, string> memoryConfig)


### PR DESCRIPTION
Example of how it is used:

```c#
                LogManager.Setup()
                    .SetupExtensions(s => s.AutoLoadAssemblies(false))
                    .SetupExtensionLogging(s => s.LoadNLogLoggingConfiguration(config));
```