### PR TITLE
Renaming LoadNLogConfigFromSection  to LoadConfigurationFromSection

### DIFF
--- a/examples/NetCore2/ConsoleExampleJsonConfig/Program.cs
+++ b/examples/NetCore2/ConsoleExampleJsonConfig/Program.cs
@@ -22,7 +22,7 @@ namespace ConsoleExample
 
                 LogManager.Setup()
                     .SetupExtensions(s => s.AutoLoadAssemblies(false))
-                    .LoadNLogConfigFromSection(config);
+                    .LoadConfigurationFromSection(config);
 
                 var servicesProvider = BuildDi(config);
                 using (servicesProvider as IDisposable)

--- a/src/NLog.Extensions.Logging/Config/SetupBuilderExtensions.cs
+++ b/src/NLog.Extensions.Logging/Config/SetupBuilderExtensions.cs
@@ -11,13 +11,16 @@ namespace NLog.Extensions.Logging
         /// <summary>
         /// Loads NLog LoggingConfiguration from appsettings.json from NLog-section
         /// </summary>
-        public static ISetupBuilder LoadNLogConfigFromSection(this ISetupBuilder setupBuilder, Microsoft.Extensions.Configuration.IConfiguration configuration)
+        public static ISetupBuilder LoadConfigurationFromSection(this ISetupBuilder setupBuilder, Microsoft.Extensions.Configuration.IConfiguration configuration, string configSection = "NLog")
         {
             setupBuilder.SetupExtensions(s => s.RegisterConfigSettings(configuration));
-            var nlogConfig = configuration.GetSection("NLog");
-            if (nlogConfig != null && nlogConfig.GetChildren().Any())
+            if (!string.IsNullOrEmpty(configSection))
             {
-                setupBuilder.LogFactory.Configuration = new NLogLoggingConfiguration(nlogConfig, setupBuilder.LogFactory);
+                var nlogConfig = configuration.GetSection(configSection);
+                if (nlogConfig != null && nlogConfig.GetChildren().Any())
+                {
+                    setupBuilder.LogFactory.Configuration = new NLogLoggingConfiguration(nlogConfig, setupBuilder.LogFactory);
+                }
             }
             return setupBuilder;
         }

--- a/test/NLog.Extensions.Logging.Tests/NLogLoggingConfigurationTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogLoggingConfigurationTests.cs
@@ -171,7 +171,7 @@ namespace NLog.Extensions.Logging.Tests
         }
 
         [Fact]
-        public void SetupBuilderNLogLoggingConfiguration()
+        public void SetupBuilderLoadConfigurationFromSection()
         {
             var memoryConfig = CreateMemoryConfigConsoleTargetAndRule();
             memoryConfig["NLog:Targets:file:type"] = "File";
@@ -181,7 +181,7 @@ namespace NLog.Extensions.Logging.Tests
             var logFactory = new LogFactory();
             logFactory.Setup()
                 .SetupExtensions(s => s.AutoLoadAssemblies(false))
-                .LoadNLogConfigFromSection(configuration);
+                .LoadConfigurationFromSection(configuration);
 
             Assert.Single(logFactory.Configuration.LoggingRules);
             Assert.Equal(2, logFactory.Configuration.LoggingRules[0].Targets.Count);


### PR DESCRIPTION
Adjusted #412

Updated example:

```c#
                LogManager.Setup()
                    .SetupExtensions(s => s.AutoLoadAssemblies(false))
                    .LoadConfigurationFromSection(config);
```

Matches: https://github.com/NLog/NLog/pull/3871 for NLog 4.7.1

Allow override of `configSection` to support `"AzureFunctionsJobHost:NLog"`