### PR TITLE
Reading JSON config - Trim keys as Json allows spaces in keys

### DIFF
--- a/test/NLog.Extensions.Logging.Tests/NLogLoggingConfigurationTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogLoggingConfigurationTests.cs
@@ -27,7 +27,24 @@ namespace NLog.Extensions.Logging.Tests
             Assert.Single(logConfig.AllTargets.Where(t => t is ConsoleTarget));
             Assert.Equal("hello.txt", (logConfig.FindTargetByName("file") as FileTarget)?.FileName.Render(LogEventInfo.CreateNullEvent()));
         }
-        
+
+        [Fact]
+        public void LoadSimpleConfigAndTrimSpace()
+        {
+            var memoryConfig = CreateMemoryConfigConsoleTargetAndRule();
+            memoryConfig["NLog:Targets:file:type"] = "File";
+            memoryConfig["NLog:Targets:file:fileName "] = "hello.txt";
+
+            var logConfig = CreateNLogLoggingConfigurationWithNLogSection(memoryConfig);
+
+            Assert.Single(logConfig.LoggingRules);
+            Assert.Equal(2, logConfig.LoggingRules[0].Targets.Count);
+            Assert.Equal(2, logConfig.AllTargets.Count);
+            Assert.Single(logConfig.AllTargets.Where(t => t is FileTarget));
+            Assert.Single(logConfig.AllTargets.Where(t => t is ConsoleTarget));
+            Assert.Equal("hello.txt", (logConfig.FindTargetByName("file") as FileTarget)?.FileName.Render(LogEventInfo.CreateNullEvent()));
+        }
+
         [Fact]
         public void LoadWrapperConfig()
         {


### PR DESCRIPTION
Spaces are automatically ignore in xml:

```xml
<target type="file"    fileName="hello.txt" />
```

But not with json:

```json
"file" {
  "  fileName": "hello.txt"
}
```

See also: https://stackoverflow.com/a/61549064/193178