### PR TITLE
NLogLoggingConfiguration - Add support for config variables with JsonLayout

### DIFF
--- a/src/NLog.Extensions.Logging/Config/NLogLoggingConfiguration.cs
+++ b/src/NLog.Extensions.Logging/Config/NLogLoggingConfiguration.cs
@@ -157,15 +157,6 @@ namespace NLog.Extensions.Logging
 
             private IEnumerable<KeyValuePair<string, string>> GetValues()
             {
-                var children = _configurationSection.GetChildren();
-                foreach (var child in children)
-                {
-                    if (!child.GetChildren().Any())
-                    {
-                        yield return new KeyValuePair<string, string>(GetConfigKey(child), child.Value);
-                    }
-                }
-
                 if (_nameOverride != null)
                 {
                     if (ReferenceEquals(_nameOverride, DefaultTargetParameters))
@@ -179,7 +170,20 @@ namespace NLog.Extensions.Logging
 
                     if (ReferenceEquals(_nameOverride, VariableKey))
                     {
-                        yield return new KeyValuePair<string, string>("value", _configurationSection.Value);
+                        var value = _configurationSection.Value;
+                        if (value != null)
+                            yield return new KeyValuePair<string, string>("value", value);
+                        else
+                            yield break;    // Signal to NLog Config Parser to check GetChildren() for variable layout
+                    }
+                }
+
+                var children = _configurationSection.GetChildren();
+                foreach (var child in children)
+                {
+                    if (!child.GetChildren().Any())
+                    {
+                        yield return new KeyValuePair<string, string>(GetConfigKey(child), child.Value);
                     }
                 }
             }
@@ -204,10 +208,17 @@ namespace NLog.Extensions.Logging
                     }
                 }
 
-                var children = _configurationSection.GetChildren();
-                foreach (var loggingConfigurationElement in GetChildren(children, variables, isTargetsSection))
+                if (ReferenceEquals(_nameOverride, VariableKey) && _configurationSection.Value == null)
                 {
-                    yield return loggingConfigurationElement;
+                    yield return new LoggingConfigurationElement(_configurationSection, false);
+                }
+                else
+                {
+                    var children = _configurationSection.GetChildren();
+                    foreach (var loggingConfigurationElement in GetChildren(children, variables, isTargetsSection))
+                    {
+                        yield return loggingConfigurationElement;
+                    }
                 }
             }
 


### PR DESCRIPTION
Then one can do like this with NLog 5.0 (See also https://github.com/NLog/NLog/pull/3459)

```json
{
    "NLog": {
        "throwConfigExceptions": true,
        "variables": {
            "myJson": {
                "type": "JsonLayout",
                "Attributes": [
                    { "name": "short_date", "layout": "${shortdate}" },
                    { "name": "message", "layout": "${message" }
                ]
            }
         },
        "targets": {
            "console": {
                "type": "Console",
                "layout": "${var:myJson}"
            }
        },
        "rules": [
            {
                "logger": "*",
                "minLevel": "Trace",
                "writeTo": "Console"
            }
        ]
    }
}
```

So the console gives output like this:

```
{ "short_date": "2021-01-06", "message": "Doing hard work! \"Action1\"" }
{ "short_date": "2021-01-06", "message": "Doing hard work! \"Action1\"" }
```