### PR TITLE
MicrosoftILoggerTarget - Add support for override LoggerName when using ILoggerFactory

### DIFF
--- a/src/NLog.Extensions.Logging/Targets/MicrosoftILoggerTarget.cs
+++ b/src/NLog.Extensions.Logging/Targets/MicrosoftILoggerTarget.cs
@@ -30,6 +30,11 @@ namespace NLog.Extensions.Logging
         public Layout EventName { get; set; }
 
         /// <summary>
+        /// Override name of ILogger, when target has been initialized with <see cref="Microsoft.Extensions.Logging.ILoggerFactory"/>
+        /// </summary>
+        public Layout LoggerName { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MicrosoftILoggerTarget" /> class.
         /// </summary>
         /// <param name="logger">Microsoft ILogger singleton instance</param>
@@ -111,7 +116,12 @@ namespace NLog.Extensions.Logging
 
         private Microsoft.Extensions.Logging.ILogger CreateFromLoggerFactory(LogEventInfo logEvent)
         {
-            var loggerName = string.IsNullOrEmpty(logEvent.LoggerName) ? "NLog" : logEvent.LoggerName;
+            var loggerName = logEvent.LoggerName;
+            if (!ReferenceEquals(LoggerName, null))
+                loggerName = RenderLogEvent(LoggerName, logEvent);
+            if (string.IsNullOrEmpty(loggerName))
+                loggerName = "NLog";
+
             if (!_loggers.TryGetValue(loggerName, out var logger))
             {
                 logger = _loggerFactory.CreateLogger(loggerName);

--- a/test/NLog.Extensions.Logging.Tests/MicrosoftILoggerTargetTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/MicrosoftILoggerTargetTests.cs
@@ -34,6 +34,26 @@ namespace NLog.Extensions.Logging.Tests
 
             // Assert
             Assert.Single(mock.Loggers);
+            Assert.Equal(GetType().ToString(), mock.Loggers.First().Key);
+            Assert.Equal("Hello World", mock.Loggers.First().Value.LastLogMessage);
+            Assert.Single(mock.Loggers.First().Value.LastLogProperties);
+            Assert.Equal("Hello World", mock.Loggers.First().Value.LastLogProperties[0].Value);
+        }
+
+        [Fact]
+        public void OverrideLoggerNameILoggerFactoryMessageTest()
+        {
+            // Arrange
+            var (logger, mock) = CreateLoggerFactoryMock(out var microsoftTarget);
+            microsoftTarget.LoggerName = "${mdlc:FunctionName}";
+
+            // Act
+            using (NLog.MappedDiagnosticsLogicalContext.SetScoped("FunctionName", nameof(OverrideLoggerNameILoggerFactoryMessageTest)))
+                logger.Info("Hello World");
+
+            // Assert
+            Assert.Single(mock.Loggers);
+            Assert.Equal(nameof(OverrideLoggerNameILoggerFactoryMessageTest), mock.Loggers.First().Key);
             Assert.Equal("Hello World", mock.Loggers.First().Value.LastLogMessage);
             Assert.Single(mock.Loggers.First().Value.LastLogProperties);
             Assert.Equal("Hello World", mock.Loggers.First().Value.LastLogProperties[0].Value);


### PR DESCRIPTION
Then output from NLog Loggers can be redirected to match function-name:

```c#
//setup target to forward NLog logs to ILogger
//NOTE: string passed to CreateLogger must match "function.<function name>" or logs will not show in Log Stream
var msLoggerFactory = serviceProvider.GetService<ILoggerFactory>();
var msLogger = msLoggerFactory.CreateLogger("Function.TestLog");
var nLogToMsLogTarget = new MicrosoftILoggerTarget(msLogger) { LoggerName = "${mdlc:FunctionName}" };
```

And one can then forward the ILogger-name to NLog like this:

```c#
    [FunctionName("TestLog")]
    public static async Task<IActionResult> TestLog([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]
                                                HttpRequest req, ILogger log)
    {
        using (NLog.MappedDiagnosticsLogicalContext.SetScoped("FunctionName", log.ToString()))
        {
           //shows in both Application Insights and Log Stream.
           log.LogInformation("Log From ILogger");

           //shows in Application Insights but not in Log Stream.
           _logger.Info("Log From NLog");

           return new OkObjectResult("OK");
        }
    }
```

See also: https://stackoverflow.com/questions/66357471/nlog-in-azure-function-log-streams-using-nlog-config