### PR TITLE
NLogProviderOptions - Added LoggingConfigurationSectionName

### DIFF
--- a/src/NLog.Extensions.Hosting/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Hosting/Extensions/ConfigureExtensions.cs
@@ -2,9 +2,7 @@
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using NLog.Config;
 using NLog.Extensions.Logging;
 
@@ -52,9 +50,14 @@ namespace NLog.Extensions.Hosting
         {
             configuration = SetupConfiguration(serviceProvider, configuration);
             NLogLoggerProvider provider = new NLogLoggerProvider(options);
-            if (configuration != null && options == null)
+            if (configuration != null)
             {
-                provider.Configure(configuration.GetSection("Logging:NLog"));
+                if (options == null)
+                {
+                    provider.Configure(configuration.GetSection("Logging:NLog"));
+                }
+
+                provider.TryLoadConfigurationFromSection(configuration);
             }
             return provider;
         }

--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -250,10 +250,16 @@ namespace NLog.Extensions.Logging
         {
             NLogLoggerProvider provider = new NLogLoggerProvider(options ?? NLogProviderOptions.Default, logFactory ?? LogManager.LogFactory);
             configuration = SetupConfiguration(serviceProvider, configuration);
-            if (configuration != null && options == null)
+            if (configuration != null)
             {
-                provider.Configure(configuration.GetSection("Logging:NLog"));
+                if (options == null)
+                {
+                    provider.Configure(configuration.GetSection("Logging:NLog"));
+                }
+
+                provider.TryLoadConfigurationFromSection(configuration);
             }
+
             return provider;
         }
 

--- a/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
+++ b/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
@@ -37,19 +37,19 @@
 
         internal static void TryLoadConfigurationFromSection(this NLogLoggerProvider loggerProvider, IConfiguration configuration)
         {
-            if (!string.IsNullOrEmpty(loggerProvider.Options.LoadConfigurationFromSection))
+            if (string.IsNullOrEmpty(loggerProvider.Options.LoadConfigurationFromSection))
+                return;
+
+            var nlogConfig = configuration.GetSection(loggerProvider.Options.LoadConfigurationFromSection);
+            if (nlogConfig?.GetChildren()?.Any() == true)
             {
-                var nlogConfig = configuration.GetSection(loggerProvider.Options.LoadConfigurationFromSection);
-                if (nlogConfig?.GetChildren()?.Any() == true)
+                loggerProvider.LogFactory.Setup().LoadConfiguration(configBuilder =>
                 {
-                    loggerProvider.LogFactory.Setup().LoadConfiguration(configBuilder =>
+                    if (configBuilder.Configuration.LoggingRules.Count == 0 && configBuilder.Configuration.AllTargets.Count == 0)
                     {
-                        if (configBuilder.Configuration.LoggingRules.Count == 0 && configBuilder.Configuration.AllTargets.Count == 0)
-                        {
-                            configBuilder.Configuration = new NLogLoggingConfiguration(nlogConfig);
-                        }
-                    });
-                }
+                        configBuilder.Configuration = new NLogLoggingConfiguration(nlogConfig);
+                    }
+                });
             }
         }
     }

--- a/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
+++ b/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
@@ -1,14 +1,17 @@
 ﻿namespace NLog.Extensions.Logging
 {
-#if !NETCORE1_0
     using System;
+    using System.Linq;
     using Microsoft.Extensions.Configuration;
+#if !NETCORE1_0
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Logging;
+#endif
 
     internal static class RegisterNLogLoggingProvider
     {
+#if !NETCORE1_0
         internal static void TryAddNLogLoggingProvider(this IServiceCollection services, Action<IServiceCollection, Action<ILoggingBuilder>> addLogging, IConfiguration configuration, NLogProviderOptions options, Func<IServiceProvider, IConfiguration, NLogProviderOptions, NLogLoggerProvider> factory)
         {
             var sharedFactory = factory;
@@ -30,6 +33,24 @@
                 addLogging?.Invoke(services, (builder) => builder?.AddFilter<NLogLoggerProvider>(null, Microsoft.Extensions.Logging.LogLevel.Trace));
             }
         }
-    }
 #endif
+
+        internal static void TryLoadConfigurationFromSection(this NLogLoggerProvider loggerProvider, IConfiguration configuration)
+        {
+            if (!string.IsNullOrEmpty(loggerProvider.Options.LoadConfigurationFromSection))
+            {
+                var nlogConfig = configuration.GetSection(loggerProvider.Options.LoadConfigurationFromSection);
+                if (nlogConfig?.GetChildren()?.Any() == true)
+                {
+                    loggerProvider.LogFactory.Setup().LoadConfiguration(configBuilder =>
+                    {
+                        if (configBuilder.Configuration.LoggingRules.Count == 0 && configBuilder.Configuration.AllTargets.Count == 0)
+                        {
+                            configBuilder.Configuration = new NLogLoggingConfiguration(nlogConfig);
+                        }
+                    });
+                }
+            }
+        }
+    }
 }

--- a/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
+++ b/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
@@ -37,10 +37,10 @@
 
         internal static void TryLoadConfigurationFromSection(this NLogLoggerProvider loggerProvider, IConfiguration configuration)
         {
-            if (string.IsNullOrEmpty(loggerProvider.Options.LoadConfigurationFromSection))
+            if (string.IsNullOrEmpty(loggerProvider.Options.LoggingConfigurationSectionName))
                 return;
 
-            var nlogConfig = configuration.GetSection(loggerProvider.Options.LoadConfigurationFromSection);
+            var nlogConfig = configuration.GetSection(loggerProvider.Options.LoggingConfigurationSectionName);
             if (nlogConfig?.GetChildren()?.Any() == true)
             {
                 loggerProvider.LogFactory.Setup().LoadConfiguration(configBuilder =>

--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -71,7 +71,7 @@
         /// <summary>
         /// Checks the Host Configuration for the specified section-name, and tries to load NLog-LoggingConfiguration after creation of NLogLoggerProvider
         /// </summary>
-        public string LoadConfigurationFromSection { get; set; }
+        public string LoggingConfigurationSectionName { get; set; }
 
         /// <summary>Initializes a new instance NLogProviderOptions with default values.</summary>
         public NLogProviderOptions()

--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -68,6 +68,11 @@
         /// <remarks>This option affects the building of service configuration, so assigning it from appsettings.json has no effect (loaded after).</remarks>
         public bool ReplaceLoggerFactory { get; set; }
 
+        /// <summary>
+        /// Checks the Host Configuration for the specified section-name, and tries to load NLog-LoggingConfiguration after creation of NLogLoggerProvider
+        /// </summary>
+        public string LoadConfigurationFromSection { get; set; }
+
         /// <summary>Initializes a new instance NLogProviderOptions with default values.</summary>
         public NLogProviderOptions()
         {

--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -71,6 +71,7 @@
         /// <summary>
         /// Checks the Host Configuration for the specified section-name, and tries to load NLog-LoggingConfiguration after creation of NLogLoggerProvider
         /// </summary>
+        /// <remarks>Will only attempt to load NLog-LoggingConfiguration if valid section-name, and NLog-LoggingConfiguration has not been loaded already.</remarks>
         public string LoggingConfigurationSectionName { get; set; }
 
         /// <summary>Initializes a new instance NLogProviderOptions with default values.</summary>

--- a/test/NLog.Extensions.Hosting.Tests/ExtensionMethodTests.cs
+++ b/test/NLog.Extensions.Hosting.Tests/ExtensionMethodTests.cs
@@ -92,5 +92,30 @@ namespace NLog.Extensions.Hosting.Tests
 
             Assert.Equal(typeof(NLogLoggerFactory), loggerFactory.GetType());
         }
+
+        [Fact]
+        public void UseNLog_LoadConfigurationFromSection()
+        {
+            var host = new HostBuilder().ConfigureAppConfiguration((context, config) =>
+            {
+                var memoryConfig = new Dictionary<string, string>();
+                memoryConfig["NLog:Rules:0:logger"] = "*";
+                memoryConfig["NLog:Rules:0:minLevel"] = "Trace";
+                memoryConfig["NLog:Rules:0:writeTo"] = "inMemory";
+                memoryConfig["NLog:Targets:inMemory:type"] = "Memory";
+                memoryConfig["NLog:Targets:inMemory:layout"] = "${logger}|${message}|${configsetting:NLog.Targets.inMemory.type}";
+                config.AddInMemoryCollection(memoryConfig);
+            }).UseNLog(new NLogProviderOptions() { LoadConfigurationFromSection = "NLog", ReplaceLoggerFactory = true }).Build();
+
+            var loggerFact = host.Services.GetService<ILoggerFactory>();
+            var logger = loggerFact.CreateLogger("logger1");
+            logger.LogError("error1");
+
+            var loggerProvider = host.Services.GetService<ILoggerProvider>() as NLogLoggerProvider;
+            var logged = loggerProvider.LogFactory.Configuration.FindTargetByName<Targets.MemoryTarget>("inMemory").Logs;
+
+            Assert.Single(logged);
+            Assert.Equal("logger1|error1|Memory", logged[0]);
+        }
     }
 }

--- a/test/NLog.Extensions.Hosting.Tests/ExtensionMethodTests.cs
+++ b/test/NLog.Extensions.Hosting.Tests/ExtensionMethodTests.cs
@@ -105,7 +105,7 @@ namespace NLog.Extensions.Hosting.Tests
                 memoryConfig["NLog:Targets:inMemory:type"] = "Memory";
                 memoryConfig["NLog:Targets:inMemory:layout"] = "${logger}|${message}|${configsetting:NLog.Targets.inMemory.type}";
                 config.AddInMemoryCollection(memoryConfig);
-            }).UseNLog(new NLogProviderOptions() { LoadConfigurationFromSection = "NLog", ReplaceLoggerFactory = true }).Build();
+            }).UseNLog(new NLogProviderOptions() { LoggingConfigurationSectionName = "NLog", ReplaceLoggerFactory = true }).Build();
 
             var loggerFact = host.Services.GetService<ILoggerFactory>();
             var logger = loggerFact.CreateLogger("logger1");


### PR DESCRIPTION
Enables automatic loading of NLog-LoggingConfiguration from appsettings.json when the following conditions are true:
- No configuration has been loaded already
- NLogProviderOptions.LoggingConfigurationSectionName has been assigned. Ex. to "NLog"
- The available host-configuration has the specified section, and it contains config-items.

With NLog 5.0 then the default-value can be changed to "NLog" so it will always automatically load NLog LoggingConfiguration from `appsettings.json` (if no other configuration has been loaded already)