### PR TITLE
NLogLogger - Faster checking if LogLevel IsEnabled

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -29,8 +29,7 @@ namespace NLog.Extensions.Logging
 
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            var nLogLogLevel = ConvertLogLevel(logLevel);
-            if (!_logger.IsEnabled(nLogLogLevel))
+            if (!IsLogLevelEnabled(logLevel))
             {
                 return;
             }
@@ -40,7 +39,7 @@ namespace NLog.Extensions.Logging
                 throw new ArgumentNullException(nameof(formatter));
             }
 
-            LogEventInfo eventInfo = CreateLogEventInfo(nLogLogLevel, state, exception, formatter);
+            LogEventInfo eventInfo = CreateLogEventInfo(ConvertLogLevel(logLevel), state, exception, formatter);
 
             CaptureEventId(eventInfo, eventId);
 
@@ -390,16 +389,28 @@ namespace NLog.Extensions.Logging
         /// <returns></returns>
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
         {
-            var convertLogLevel = ConvertLogLevel(logLevel);
-            return IsEnabled(convertLogLevel);
+            return IsLogLevelEnabled(logLevel);
         }
 
-        /// <summary>
-        /// Is logging enabled for this logger at this <paramref name="logLevel"/>?
-        /// </summary>
-        private bool IsEnabled(LogLevel logLevel)
+        private bool IsLogLevelEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
         {
-            return _logger.IsEnabled(logLevel);
+            switch (logLevel)
+            {
+                case Microsoft.Extensions.Logging.LogLevel.Trace:
+                    return _logger.IsTraceEnabled;
+                case Microsoft.Extensions.Logging.LogLevel.Debug:
+                    return _logger.IsDebugEnabled;
+                case Microsoft.Extensions.Logging.LogLevel.Information:
+                    return _logger.IsInfoEnabled;
+                case Microsoft.Extensions.Logging.LogLevel.Warning:
+                    return _logger.IsWarnEnabled;
+                case Microsoft.Extensions.Logging.LogLevel.Error:
+                    return _logger.IsErrorEnabled;
+                case Microsoft.Extensions.Logging.LogLevel.Critical:
+                    return _logger.IsFatalEnabled;
+                default:
+                    return false;
+            }
         }
 
         /// <inheritdoc />

--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -57,13 +57,13 @@
         public bool IncludeActivtyIdsWithBeginScope { get; set; }
 
         /// <summary>
-        /// Resets the default Microsoft LoggerFactory Filter for the <see cref="NLogLoggerProvider"/>
+        /// Resets the default Microsoft LoggerFactory Filter for the <see cref="NLogLoggerProvider"/>, and instead only uses NLog LoggingRules.
         /// </summary>
         /// <remarks>This option affects the building of service configuration, so assigning it from appsettings.json has no effect (loaded after).</remarks>
         public bool RemoveLoggerFactoryFilter { get; set; }
 
         /// <summary>
-        /// Replace Microsoft LoggerFactory with a pure <see cref="NLogLoggerFactory" />
+        /// Replace Microsoft LoggerFactory with a pure <see cref="NLogLoggerFactory" />, and disables Microsoft Filter Logic and multiple LoggingProvider support.
         /// </summary>
         /// <remarks>This option affects the building of service configuration, so assigning it from appsettings.json has no effect (loaded after).</remarks>
         public bool ReplaceLoggerFactory { get; set; }


### PR DESCRIPTION
When using `NLogProviderOptions.RemoveLoggerFactoryFilter = true`, then Microsoft LoggerFactory will arrive with all LogEvents on all LogLevels (No longer "protected" by Microsoft Filtering-logic)

Reduced to single switch from Microsoft LogLevel to NLog Logger-IsEnabled. For faster discarding of Debug / Trace-vents.

Instead of making 2 switches:
- Microsoft LogLevel -> NLog LogLevel
- NLog LogLevel -> NLog Logger-IsEnabled.