### PR TITLE
NLogLoggerProvider - Always load from appsettings when possible

### DIFF
--- a/src/NLog.Extensions.Hosting/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Hosting/Extensions/ConfigureExtensions.cs
@@ -48,17 +48,14 @@ namespace NLog.Extensions.Hosting
 
         private static NLogLoggerProvider CreateNLogLoggerProvider(IServiceProvider serviceProvider, IConfiguration configuration, NLogProviderOptions options)
         {
-            configuration = SetupConfiguration(serviceProvider, configuration);
             NLogLoggerProvider provider = new NLogLoggerProvider(options);
+            configuration = SetupConfiguration(serviceProvider, configuration);
             if (configuration != null)
             {
-                if (options == null)
-                {
-                    provider.Configure(configuration.GetSection("Logging:NLog"));
-                }
-
+                provider.Configure(configuration.GetSection("Logging:NLog"));
                 provider.TryLoadConfigurationFromSection(configuration);
             }
+
             return provider;
         }
 

--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -252,11 +252,7 @@ namespace NLog.Extensions.Logging
             configuration = SetupConfiguration(serviceProvider, configuration);
             if (configuration != null)
             {
-                if (options == null)
-                {
-                    provider.Configure(configuration.GetSection("Logging:NLog"));
-                }
-
+                provider.Configure(configuration.GetSection("Logging:NLog"));
                 provider.TryLoadConfigurationFromSection(configuration);
             }
 


### PR DESCRIPTION
Better experience out-of-the-box when running on Azure Functions with special application-lifetime-events.