### PR TITLE
NLogProviderOptions with support for CaptureEventId

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/EventIdCaptureType.cs
+++ b/src/NLog.Extensions.Logging/Logging/EventIdCaptureType.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace NLog.Extensions.Logging
+{
+    /// <summary>
+    /// Defines EventId capture options
+    /// </summary>
+    [Flags]
+    public enum EventIdCaptureType
+    {
+        /// <summary>
+        /// Skip capture
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Capture entire <see cref="Microsoft.Extensions.Logging.EventId"/> as "EventId"-property (with boxing)
+        /// </summary>
+        EventId = 1,
+        /// <summary>
+        /// Capture <see cref="Microsoft.Extensions.Logging.EventId.Id"/> as "EventId_Id"-property.
+        /// </summary>
+        EventId_Id = 2,
+        /// <summary>
+        /// Capture <see cref="Microsoft.Extensions.Logging.EventId.Name"/> as "EventId_Name"-property.
+        /// </summary>
+        EventId_Name = 4,
+        /// <summary>
+        /// Capture all properties (Legacy)
+        /// </summary>
+        All = EventId | EventId_Id | EventId_Name,
+    }
+}

--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -200,7 +200,7 @@ namespace NLog.Extensions.Logging
         }
 
         private static readonly object[] SingleItemArray = { null };
-        private static readonly IList<MessageTemplateParameter> EmptyParameterArray = new MessageTemplateParameter[] { };
+        private static readonly IList<MessageTemplateParameter> EmptyParameterArray = Array.Empty<MessageTemplateParameter>();
 
         /// <summary>
         /// Are all parameters positional and correctly mapped?
@@ -328,7 +328,7 @@ namespace NLog.Extensions.Logging
 
         private void CaptureEventId(LogEventInfo eventInfo, EventId eventId)
         {
-            if (_options.CaptureMessageProperties && (!_options.IgnoreEmptyEventId || eventId.Id != 0 || !String.IsNullOrEmpty(eventId.Name)))
+            if (_options.CaptureMessageProperties && _options.CaptureEventId != EventIdCaptureType.None && (!_options.IgnoreEmptyEventId || eventId.Id != 0 || !String.IsNullOrEmpty(eventId.Name)))
             {
                 // Attempt to reuse the same string-allocations based on the current <see cref="NLogProviderOptions.EventIdSeparator"/>
                 var eventIdPropertyNames = _eventIdPropertyNames ?? new Tuple<string, string, string>(null, null, null);
@@ -341,16 +341,12 @@ namespace NLog.Extensions.Logging
 
                 var idIsZero = eventId.Id == 0;
                 var eventIdObj = idIsZero ? ZeroEventId : GetEventId(eventId.Id);
-                eventInfo.Properties[eventIdPropertyNames.Item2] = eventIdObj;
-                if (_options.CaptureEntireEventId)
-                {
+                if ((_options.CaptureEventId & EventIdCaptureType.EventId_Id) != 0)
+                    eventInfo.Properties[eventIdPropertyNames.Item2] = eventIdObj;
+                if ((_options.CaptureEventId & EventIdCaptureType.EventId_Name) != 0 && (!string.IsNullOrEmpty(eventId.Name) || !_options.IgnoreEmptyEventId))
                     eventInfo.Properties[eventIdPropertyNames.Item3] = eventId.Name;
+                if ((_options.CaptureEventId & EventIdCaptureType.EventId) != 0)
                     eventInfo.Properties["EventId"] = idIsZero && eventId.Name == null ? EmptyEventId : eventId;
-                }
-                else if (!string.IsNullOrEmpty(eventId.Name))
-                {
-                    eventInfo.Properties[eventIdPropertyNames.Item3] = eventId.Name;
-                }
             }
         }
 

--- a/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
@@ -14,7 +14,6 @@ namespace NLog.Extensions.Logging
         private static readonly NLogMessageParameterList EmptyList = new NLogMessageParameterList(new KeyValuePair<string, object>[0]);
         private static readonly NLogMessageParameterList OriginalMessageList = new NLogMessageParameterList(new[] { new KeyValuePair<string, object>(NLogLogger.OriginalFormatPropertyName, string.Empty) });
 
-        public bool HasOriginalMessage => _originalMessageIndex.HasValue;
         private readonly int? _originalMessageIndex;
 
         public bool HasComplexParameters => _hasMessageTemplateCapture || _isMixedPositional;
@@ -60,7 +59,7 @@ namespace NLog.Extensions.Logging
 
         public bool HasMessageTemplateSyntax(bool parseMessageTemplates)
         {
-            return HasOriginalMessage && (HasComplexParameters || (parseMessageTemplates && Count > 0));
+            return _originalMessageIndex.HasValue && (HasComplexParameters || (parseMessageTemplates && Count > 0));
         }
 
         public string GetOriginalMessage(IReadOnlyList<KeyValuePair<string, object>> messageProperties)

--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -13,9 +13,17 @@ namespace NLog.Extensions.Logging
         public string EventIdSeparator { get; set; } = "_";
 
         /// <summary>
-        /// Skip creating "EventId_Id" and "EventId_Name" as <see cref="LogEventInfo.Properties" /> when <c>default(EventId)</c>
+        /// Skip capture of "EventId_Id" and "EventId_Name" as <see cref="LogEventInfo.Properties" /> when <c>default(EventId)</c>
         /// </summary>
         public bool IgnoreEmptyEventId { get; set; } = true;
+
+        /// <summary>
+        /// Control capture of <see cref="Microsoft.Extensions.Logging.EventId"/> as "EventId"-property.
+        /// </summary>
+        /// <remarks>
+        /// Enabling capture of the entire "EventId" will increase memory allocation and gives a performance hit. Faster to use "EventId_Id" + "EventId_Name".
+        /// </remarks>
+        public EventIdCaptureType CaptureEventId { get; set; } = EventIdCaptureType.EventId_Id | EventIdCaptureType.EventId_Name;
 
         /// <summary>
         /// Enable structured logging by capturing message template parameters with support for "@" and "$". Enables use of ${message:raw=true}
@@ -86,14 +94,6 @@ namespace NLog.Extensions.Logging
         /// </summary>
         /// <remarks>Will only attempt to load NLog-LoggingConfiguration if valid section-name, and NLog-LoggingConfiguration has not been loaded already.</remarks>
         public string LoggingConfigurationSectionName { get; set; } = "NLog";
-
-        /// <summary>
-        /// Enable additional capture of the entire <see cref="Microsoft.Extensions.Logging.EventId"/> as "EventId"-property.
-        /// </summary>
-        /// <remarks>
-        /// Enabling capture of the entire "EventId" will increase memory allocation and gives a performance hit. Faster to use "EventId_Id" + "EventId_Name".
-        /// </remarks>
-        public bool CaptureEntireEventId { get; set; }
 
         /// <summary>
         /// Enable NLog Targets and Layouts to perform dependency lookup using the Microsoft Dependency Injection IServiceProvider

--- a/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
@@ -45,7 +45,7 @@ namespace NLog.Extensions.Logging.Tests.Extensions
             var config = CreateConfigWithMemoryTarget(out var memoryTarget, $"${{event-properties:{eventPropery}}} - ${{message}}");
 
             // Act
-            loggerFactory.AddNLog(new NLogProviderOptions { EventIdSeparator = "_", CaptureEntireEventId = captureEntireEventId });
+            loggerFactory.AddNLog(new NLogProviderOptions { EventIdSeparator = "_", CaptureEventId = captureEntireEventId ? EventIdCaptureType.All : EventIdCaptureType.EventId_Id | EventIdCaptureType.EventId_Name });
             LogManager.Configuration = config;
             var logger = loggerFactory.CreateLogger("logger1");
             logger.LogInformation(new EventId(2, "eventId_2"), "test message with {0} arg", 1);
@@ -108,7 +108,7 @@ namespace NLog.Extensions.Logging.Tests.Extensions
             // Arrange
             ILoggingBuilder builder = new LoggingBuilderStub();
             var config = CreateConfigWithMemoryTarget(out var memoryTarget, $"${{event-properties:{eventPropery}}} - ${{message}}");
-            var options = new NLogProviderOptions { EventIdSeparator = "_", CaptureEntireEventId = captureEntireEventId };
+            var options = new NLogProviderOptions { EventIdSeparator = "_", CaptureEventId = captureEntireEventId ? EventIdCaptureType.All : EventIdCaptureType.EventId_Id | EventIdCaptureType.EventId_Name };
 
             // Act
             builder.AddNLog(config, options);


### PR DESCRIPTION
Follow up to #319. Better granularity of how to capture EventId. See also  #537