### PR TITLE
Bump  to Visual Studio 2022 on AppVeyor + Removed .NET core 1 tests 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 5.0.0-{build} # Only change for mayor versions (e.g. 6.0)
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 skip_tags: true
 
@@ -21,8 +21,7 @@ artifacts:
 
 test_script:
   - nuget.exe install OpenCover -ExcludeVersion -DependencyVersion Ignore
-  - OpenCover\tools\OpenCover.Console.exe -register:user -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test -f netcoreapp1.1  -c debug NLog.Extensions.Logging.Tests" -filter:"+[NLog.Extensions.Logging]* +[NLog.Extensions.Hosting]* -[NLog.Extensions.Logging.Tests]* -[NLog.Extensions.Hosting.Tests]*" -output:"coverage.xml" -oldstyle -targetdir:"test"
-  - OpenCover\tools\OpenCover.Console.exe -register:user -mergeoutput -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test -f netcoreapp2.1  -c debug NLog.Extensions.Logging.Tests" -filter:"+[NLog.Extensions.Logging]* -[NLog.Extensions.Logging.Tests]*" -output:"coverage.xml" -oldstyle -targetdir:"test"
+  - OpenCover\tools\OpenCover.Console.exe -register:user -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test -f netcoreapp2.1  -c debug NLog.Extensions.Logging.Tests" -filter:"+[NLog.Extensions.Logging]* +[NLog.Extensions.Hosting]* -[NLog.Extensions.Logging.Tests]* -[NLog.Extensions.Hosting.Tests]*" -output:"coverage.xml" -oldstyle -targetdir:"test"
   - OpenCover\tools\OpenCover.Console.exe -register:user -mergeoutput -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test -f netcoreapp3.1  -c debug NLog.Extensions.Logging.Tests" -filter:"+[NLog.Extensions.Logging]* -[NLog.Extensions.Logging.Tests]*" -output:"coverage.xml" -oldstyle -targetdir:"test"
   - OpenCover\tools\OpenCover.Console.exe -register:user -mergeoutput -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test -f net5.0         -c debug NLog.Extensions.Logging.Tests" -filter:"+[NLog.Extensions.Logging]* -[NLog.Extensions.Logging.Tests]*" -output:"coverage.xml" -oldstyle -targetdir:"test"
   - OpenCover\tools\OpenCover.Console.exe -register:user -mergeoutput -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test -f netcoreapp2.1  -c debug NLog.Extensions.Hosting.Tests" -filter:"+[NLog.Extensions.Logging]* +[NLog.Extensions.Hosting]* -[NLog.Extensions.Logging.Tests]* -[NLog.Extensions.Hosting.Tests]*" -output:"coverage.xml" -oldstyle -targetdir:"test"

--- a/test/NLog.Extensions.Logging.Tests/ConfigSettingLayoutRendererTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/ConfigSettingLayoutRendererTests.cs
@@ -15,7 +15,6 @@ namespace NLog.Extensions.Logging.Tests
             Assert.Equal("MyTableName", result);
         }
 
-#if !NETCORE1_0
         [Fact]
         public void ConfigSettingGlobalConfigLookup()
         {
@@ -26,6 +25,5 @@ namespace NLog.Extensions.Logging.Tests
             var result = layoutRenderer.Render(LogEventInfo.CreateNullEvent());
             Assert.Equal("Test", result);
         }
-#endif
     }
 }

--- a/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
@@ -77,7 +77,6 @@ namespace NLog.Extensions.Logging.Tests.Extensions
         }
 #endif
 
-#if !NETCORE1_0
         [Fact]
         public void AddNLog_LoggingBuilder_LogInfo_ShouldLogToNLog()
         {
@@ -166,7 +165,6 @@ namespace NLog.Extensions.Logging.Tests.Extensions
         {
             public IServiceCollection Services { get; set; } = new ServiceCollection();
         }
-#endif
 
         private static void AssertSingleMessage(MemoryTarget memoryTarget, string expectedMessage)
         {

--- a/test/NLog.Extensions.Logging.Tests/NLog.Extensions.Logging.Tests.csproj
+++ b/test/NLog.Extensions.Logging.Tests/NLog.Extensions.Logging.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;netcoreapp3.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net461;net5.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
     <DebugType>Full</DebugType>
@@ -14,10 +14,6 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <LangVersion>latest</LangVersion>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <DefineConstants>$(DefineConstants);NETCORE1_0</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NLog.Extensions.Logging.Tests/NLogLoggingConfigurationTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogLoggingConfigurationTests.cs
@@ -13,7 +13,6 @@ namespace NLog.Extensions.Logging.Tests
         const string DefaultSectionName = "NLog";
         const string CustomSectionName = "MyCustomSection";
 
-#if !NETCORE1_0
         [Fact]
         public void LoadSimpleConfig()
         {
@@ -303,6 +302,5 @@ namespace NLog.Extensions.Logging.Tests
 
             return memoryConfig;
         }
-#endif
     }
 }


### PR DESCRIPTION
Removed netcoreapp1.1 since reached end-of-life.