### PR TITLE
Ensure event ID out of mapper range is parsed

### DIFF
--- a/src/NLog.Extensions.Logging/LayoutRenderers/MicrosoftConsoleLayoutRenderer.cs
+++ b/src/NLog.Extensions.Logging/LayoutRenderers/MicrosoftConsoleLayoutRenderer.cs
@@ -81,7 +81,7 @@ namespace NLog.Extensions.Logging
         {
             if (eventId == 0)
                 return "0";
-            else if (eventId > 0 || eventId < EventIdMapper.Length)
+            else if (eventId > 0 && eventId < EventIdMapper.Length)
                 return EventIdMapper[eventId];
             else
                 return eventId.ToString(System.Globalization.CultureInfo.InvariantCulture);

--- a/test/NLog.Extensions.Logging.Tests/MicrosoftConsoleLayoutRendererTest.cs
+++ b/test/NLog.Extensions.Logging.Tests/MicrosoftConsoleLayoutRendererTest.cs
@@ -26,6 +26,17 @@ namespace NLog.Extensions.Logging.Tests
         }
 
         [Fact]
+        public void MicrosoftConsoleLayoutRenderer_OutOfMapperBoundsEventId()
+        {
+            var layoutRenderer = new MicrosoftConsoleLayoutRenderer();
+            var exception = new ArgumentException("Test");
+            var eventId = 500;
+            var result = layoutRenderer.Render(new LogEventInfo(LogLevel.Error, "MyLogger", null, "Alert {EventId_Id}", new object[] { eventId }, exception));
+            Assert.Equal($"fail: MyLogger[{eventId}]{Environment.NewLine}      Alert 500{Environment.NewLine}{exception}", result);
+        }
+
+
+        [Fact]
         public void MicrosoftConsoleLayoutRenderer_TimestampFormat()
         {
             var timestampFormat = "hh:mm:ss";


### PR DESCRIPTION
When an EventID comes in to the MicrosoftConsoleLayout formatter, if the ID is not within the range of pre-mapped event IDs (currently 0 to 50), then it should be simply converted to a string.

See #569 for details on original issue