### PR TITLE
Fix typo in xml-docs for MicrosoftConsoleJsonLayout

### DIFF
--- a/src/NLog.Extensions.Logging/Layouts/MicrosoftConsoleJsonLayout.cs
+++ b/src/NLog.Extensions.Logging/Layouts/MicrosoftConsoleJsonLayout.cs
@@ -7,7 +7,7 @@ using NLog.Layouts;
 namespace NLog.Extensions.Logging
 {
     /// <summary>
-    /// Renders output that simulates Microsoft Json Console Formatter from AddJsonConsol
+    /// Renders output that simulates Microsoft Json Console Formatter from AddJsonConsole
     /// </summary>
     [Layout("MicrosoftConsoleJsonLayout")]
     [ThreadAgnostic]


### PR DESCRIPTION
- https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.consoleloggerextensions.addjsonconsole