### PR TITLE
Introduced NLogProviderOptions AutoShutdown that is turned off by default

### DIFF
--- a/src/NLog.Extensions.Hosting/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Hosting/Extensions/ConfigureExtensions.cs
@@ -63,11 +63,6 @@ namespace NLog.Extensions.Hosting
                 TryLoadConfigurationFromContentRootPath(provider.LogFactory, contentRootPath);
             }
 
-            if (provider.Options.ShutdownOnDispose)
-            {
-                provider.LogFactory.AutoShutdown = false;
-            }
-
             return provider;
         }
 

--- a/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
+++ b/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
@@ -80,6 +80,11 @@
                 provider.TryLoadConfigurationFromSection(configuration);
             }
 
+            if (provider.Options.ShutdownOnDispose || !provider.Options.AutoShutdown)
+            {
+                provider.LogFactory.AutoShutdown = false;
+            }
+
             return provider;
         }
 

--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -50,6 +50,11 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public bool ShutdownOnDispose { get; set; }
 
+        /// <summary>
+        /// Automatically Shutdown NLog on AppDomain.Unload or AppDomain.ProcessExit
+        /// </summary>
+        public bool AutoShutdown { get; set; }
+
 #if NET5_0
         /// <summary>
         /// Automatically include <see cref="System.Diagnostics.Activity.SpanId"/>, <see cref="System.Diagnostics.Activity.TraceId"/> and <see cref="System.Diagnostics.Activity.ParentId"/>


### PR DESCRIPTION
Now one have to explicitly turn on "AutoShutdown" when using NLog Logging Provider.

The problem with "AutoShutdown" is that AppDomain-Unload / AppDomain-ProcesExit triggers before application is completely shutdown. Thus application-exit-logging is lost.

The problem with "ShutdownOnDispose" is that Microsoft Host disposes the LoggerFactory when exception occurs, without logging the exception first.