### PR TITLE
ConfigSettingLayoutRenderer - Support escape of dot-separator

### DIFF
--- a/src/NLog.Extensions.Logging/LayoutRenderers/ConfigSettingLayoutRenderer.cs
+++ b/src/NLog.Extensions.Logging/LayoutRenderers/ConfigSettingLayoutRenderer.cs
@@ -50,7 +50,7 @@ namespace NLog.Extensions.Logging
             set
             {
                 _item = value;
-                _itemLookup = value?.Replace(".", ":");
+                _itemLookup = value?.Replace("\\.", "::").Replace(".", ":").Replace("::", ".");
             }
         }
         private string _item;

--- a/test/NLog.Extensions.Logging.Tests/ConfigSettingLayoutRendererTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/ConfigSettingLayoutRendererTests.cs
@@ -25,5 +25,16 @@ namespace NLog.Extensions.Logging.Tests
             var result = layoutRenderer.Render(LogEventInfo.CreateNullEvent());
             Assert.Equal("Test", result);
         }
+
+        [Fact]
+        public void ConfigSettingGlobalConfigEscapeLookup()
+        {
+            var memoryConfig = new Dictionary<string, string>();
+            memoryConfig["Microsoft.Logging"] = "Test";
+            ConfigSettingLayoutRenderer.DefaultConfiguration = new ConfigurationBuilder().AddInMemoryCollection(memoryConfig).Build();
+            var layoutRenderer = new ConfigSettingLayoutRenderer { Item = @"Microsoft\.Logging" };
+            var result = layoutRenderer.Render(LogEventInfo.CreateNullEvent());
+            Assert.Equal("Test", result);
+        }
     }
 }


### PR DESCRIPTION
```json
 "Logging": {
    "LogLevel": {
      "Default": "Error",
      "Microsoft": "Information",
      "Microsoft.Hosting.Lifetime": "Error"
    }
```
Can now resolved like this:
```
${configsetting:item=Logging.Microsoft\.Hosting\.Lifetime}
```