### PR TITLE
LoadConfigurationFromSection should RegisterConfigSettings without configuration assign

### DIFF
--- a/src/NLog.Extensions.Logging/Config/SetupBuilderExtensions.cs
+++ b/src/NLog.Extensions.Logging/Config/SetupBuilderExtensions.cs
@@ -13,6 +13,7 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public static ISetupBuilder LoadConfigurationFromSection(this ISetupBuilder setupBuilder, Microsoft.Extensions.Configuration.IConfiguration configuration, string configSection = "NLog")
         {
+            setupBuilder.SetupExtensions(ext => ext.RegisterExtensionsLogging(configuration));
             if (!string.IsNullOrEmpty(configSection))
             {
                 var nlogConfig = configuration.GetSection(configSection);

--- a/src/NLog.Extensions.Logging/Config/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog.Extensions.Logging/Config/SetupExtensionsBuilderExtensions.cs
@@ -14,6 +14,15 @@ namespace NLog.Extensions.Logging
         public static ISetupExtensionsBuilder RegisterConfigSettings(this ISetupExtensionsBuilder setupBuilder, IConfiguration configuration)
         {
             ConfigSettingLayoutRenderer.DefaultConfiguration = configuration;
+            return setupBuilder.RegisterExtensionsLogging(configuration);
+        }
+
+        internal static ISetupExtensionsBuilder RegisterExtensionsLogging(this ISetupExtensionsBuilder setupBuilder, IConfiguration configuration)
+        {
+            if (ConfigSettingLayoutRenderer.DefaultConfiguration is null)
+            {
+                ConfigSettingLayoutRenderer.DefaultConfiguration = configuration;
+            }
             return setupBuilder.RegisterLayoutRenderer<ConfigSettingLayoutRenderer>("configsetting").RegisterLayoutRenderer<MicrosoftConsoleLayoutRenderer>("MicrosoftConsoleLayout");
         }
     }


### PR DESCRIPTION
Follow up to #626 (Ensure extension-types are registered, before loading config, and allow config assign when unassigned)