### PR TITLE
NLogMessageParameterList - Skip property parsing when simple positional message template

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -123,7 +123,7 @@ namespace NLog.Extensions.Logging
         {
             // Parsing not needed, we take the fast route 
             var originalMessage = messageParameters.GetOriginalMessage(messageProperties) ?? message;
-            var logEvent = new LogEventInfo(nLogLogLevel, _logger.Name, originalMessage, messageParameters.IsPositional ? EmptyParameterArray : messageParameters);
+            var logEvent = new LogEventInfo(nLogLogLevel, _logger.Name, originalMessage, messageParameters);
             if (!ReferenceEquals(originalMessage, message))
             {
                 SetLogEventMessageFormatter(logEvent, messageParameters, message);

--- a/test/NLog.Extensions.Logging.Tests/Logging/NLogMessageParameterListTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Logging/NLogMessageParameterListTests.cs
@@ -13,7 +13,7 @@ namespace NLog.Extensions.Logging.Tests.Logging
         /// <inheritdoc />
         public NLogMessageParameterListTests()
         {
-            _messageParameterList = new NLogMessageParameterList(new List<KeyValuePair<string, object>>
+            _messageParameterList = NLogMessageParameterList.TryParse(new List<KeyValuePair<string, object>>
             {
                 new KeyValuePair<string, object>("nr1", "a"),
                 new KeyValuePair<string, object>("@nr2", "b"),

--- a/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
@@ -17,7 +17,7 @@ namespace NLog.Extensions.Logging.Tests
                 new KeyValuePair<string, object>("b", 3),
                 new KeyValuePair<string, object>("{OriginalFormat}", "{0}{1}{2}"),
             };
-            var list = new NLogMessageParameterList(items);
+            var list = NLogMessageParameterList.TryParse(items);
 
             Assert.Equal(2, list.Count);
             Assert.Equal(new MessageTemplateParameter("a", 2, null, CaptureType.Normal), list[0]);
@@ -35,7 +35,7 @@ namespace NLog.Extensions.Logging.Tests
                 new KeyValuePair<string, object>("{OriginalFormat}", originalFormat),
                 new KeyValuePair<string, object>("b", 3)
             };
-            var list = new NLogMessageParameterList(items);
+            var list = NLogMessageParameterList.TryParse(items);
 
             Assert.Equal(2, list.Count);
             Assert.Equal(new MessageTemplateParameter("a", 2, null, CaptureType.Normal), list[0]);
@@ -51,7 +51,7 @@ namespace NLog.Extensions.Logging.Tests
                 new KeyValuePair<string, object>("$b", 2),
                 new KeyValuePair<string, object>("@c", 3)
             };
-            var list = new NLogMessageParameterList(items);
+            var list = NLogMessageParameterList.TryParse(items);
 
             Assert.Equal(3, list.Count);
             Assert.Equal(new MessageTemplateParameter("a", 1, null, CaptureType.Normal), list[0]);


### PR DESCRIPTION
Skips capture of `LogEventInfo.Parameters`-array