### PR TITLE
NLogBeginScopeParser - Skip capture of nested state when List + Array + Dictionary

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
@@ -31,9 +31,19 @@ namespace NLog.Extensions.Logging
             {
                 if (state is IReadOnlyList<KeyValuePair<string, object>> scopePropertyList)
                 {
+                    if (scopePropertyList is IList)
+                        return ScopeContext.PushNestedStateProperties(null, scopePropertyList);  // Probably List/Array without nested state
+
                     object scopeObject = scopePropertyList;
                     scopePropertyList = ParseScopeProperties(scopePropertyList);
                     return ScopeContext.PushNestedStateProperties(scopeObject, scopePropertyList);
+                }
+                else if (state is IReadOnlyCollection<KeyValuePair<string, object>> scopeProperties)
+                {
+                    if (scopeProperties is IDictionary)
+                        return ScopeContext.PushNestedStateProperties(null, scopeProperties);    // Probably Dictionary without nested state
+                    else
+                        return ScopeContext.PushNestedStateProperties(scopeProperties, scopeProperties);
                 }
 
                 if (!(state is string))
@@ -181,7 +191,10 @@ namespace NLog.Extensions.Logging
                 propertyList.Add(propertyValue.Value);
             }
 
-            return ScopeContext.PushNestedStateProperties(scopePropertyCollection, propertyList);
+            if (scopePropertyCollection is IList || scopePropertyCollection is IDictionary)
+                return ScopeContext.PushNestedStateProperties(null, propertyList);   // Probably List/Array/Dictionary without nested state
+            else
+                return ScopeContext.PushNestedStateProperties(scopePropertyCollection, propertyList);
         }
 
         public static IDisposable CaptureScopeProperty<TState>(TState scopeProperty, ExtractorDictionary stateExtractor)

--- a/test/NLog.Extensions.Logging.Tests/CustomBeginScopeTest.cs
+++ b/test/NLog.Extensions.Logging.Tests/CustomBeginScopeTest.cs
@@ -65,6 +65,17 @@ namespace NLog.Extensions.Logging.Tests
             Assert.Equal("Nothing", target.Logs[0]);
         }
 
+        [Fact]
+        public void TestNonSerializableSaySomething()
+        {
+            var runner = GetRunner<CustomBeginScopeTestRunner>();
+            var target = new Targets.MemoryTarget { Layout = "${message}${scopeproperty:Say}" };
+            ConfigureNLog(target);
+            runner.SaySomething().Wait();
+            Assert.Single(target.Logs);
+            Assert.Equal("SaySomething", target.Logs[0]);
+        }     
+
         public class CustomBeginScopeTestRunner
         {
             private readonly ILogger<CustomBeginScopeTestRunner> _logger;
@@ -109,6 +120,18 @@ namespace NLog.Extensions.Logging.Tests
                 {
                     await Task.Yield();
                     _logger.LogInformation("Nothing");
+                }
+            }
+
+            public async Task SaySomething()
+            {
+                using (var scopeState = _logger.BeginScope(new Dictionary<string, object>()
+                {
+                    { "Say", "Something" },
+                }))
+                {
+                    await Task.Yield();
+                    _logger.LogInformation("Say");
                 }
             }
         }

--- a/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
@@ -70,7 +70,7 @@ namespace NLog.Extensions.Logging.Tests.Extensions
             var logger = loggerFactory.CreateLogger(nameof(AddNLog_LoggerFactory_IncludeActivityIdsWithBeginScope));
             var activity = new System.Diagnostics.Activity("TestActivity").SetParentId("42").Start();
             var scopeProperties = new Dictionary<string, object> { { "RequestId", "123" }, { "RequestPath", "Unknown" } };
-            using (logger.BeginScope(scopeProperties.ToList()))
+            using (logger.BeginScope(new ArraySegment<KeyValuePair<string, object>>(scopeProperties.ToArray())))
             {
                 logger.LogInformation(default(EventId), "test message with {0} arg", 1);
             }


### PR DESCRIPTION
NLog v5.1.3 now ignores `null` when used as nested-state in `ScopeContext.PushNestedStateProperties`.