### PR TITLE
NLogLoggerProvider - Replaced dynamic assembly loading with registration methods

### DIFF
--- a/examples/NetCore2/HostingExample/HostingExample.csproj
+++ b/examples/NetCore2/HostingExample/HostingExample.csproj
@@ -1,16 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>Latest</LangVersion>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -24,3 +24,7 @@ if (-Not $LastExitCode -eq 1)
 	dotnet list ./ package --vulnerable --include-transitive
 	exit 1
 }
+
+dotnet publish -r win-x64 -c release --self-contained -p:PublishTrimmed=true .\examples\NetCore2\HostingExample
+if (-Not $LastExitCode -eq 0)
+	{ exit $LastExitCode }

--- a/src/NLog.Extensions.Hosting/NLog.Extensions.Hosting.csproj
+++ b/src/NLog.Extensions.Hosting/NLog.Extensions.Hosting.csproj
@@ -35,6 +35,8 @@ For ASP.NET Core, check: https://www.nuget.org/packages/NLog.Web.AspNetCore
     <LangVersion>latest</LangVersion>
     <!-- EmbedUntrackedSources for deterministic build -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/NLog.Extensions.Logging/Config/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog.Extensions.Logging/Config/SetupExtensionsBuilderExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using NLog.Common;
 using NLog.Config;
 
 namespace NLog.Extensions.Logging
@@ -13,10 +16,47 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public static ISetupExtensionsBuilder RegisterConfigSettings(this ISetupExtensionsBuilder setupBuilder, IConfiguration configuration)
         {
+            RegisterHiddenAssembliesForCallSite();
             ConfigSettingLayoutRenderer.DefaultConfiguration = configuration ?? ConfigSettingLayoutRenderer.DefaultConfiguration;
             return setupBuilder.RegisterLayoutRenderer<ConfigSettingLayoutRenderer>("configsetting")
                                .RegisterLayoutRenderer<MicrosoftConsoleLayoutRenderer>("MicrosoftConsoleLayout")
-                               .RegisterLayout<MicrosoftConsoleJsonLayout>("MicrosoftConsoleJsonLayout");
+                               .RegisterLayout<MicrosoftConsoleJsonLayout>("MicrosoftConsoleJsonLayout")
+                               .RegisterTarget<MicrosoftILoggerTarget>("MicrosoftILogger");
         }
+
+        private static void RegisterHiddenAssembliesForCallSite()
+        {
+            InternalLogger.Debug("Hide assemblies for callsite");
+            LogManager.AddHiddenAssembly(typeof(NLogLoggerProvider).GetTypeInfo().Assembly);
+            LogManager.AddHiddenAssembly(typeof(Microsoft.Extensions.Logging.ILogger).GetTypeInfo().Assembly);
+#if !NETCORE1_0
+            LogManager.AddHiddenAssembly(typeof(Microsoft.Extensions.Logging.LoggerFactory).GetTypeInfo().Assembly);
+#else
+            SafeAddHiddenAssembly("Microsoft.Logging");
+            SafeAddHiddenAssembly("Microsoft.Extensions.Logging");
+
+            //try the Filter ext, this one is not mandatory so could fail
+            SafeAddHiddenAssembly("Microsoft.Extensions.Logging.Filter", false);
+#endif
+        }
+
+#if NETCORE1_0
+        private static void SafeAddHiddenAssembly(string assemblyName, bool logOnException = true)
+        {
+            try
+            {
+                InternalLogger.Trace("Hide {0}", assemblyName);
+                var assembly = Assembly.Load(new AssemblyName(assemblyName));
+                LogManager.AddHiddenAssembly(assembly);
+            }
+            catch (Exception ex)
+            {
+                if (logOnException)
+                {
+                    InternalLogger.Debug(ex, "Hiding assembly {0} failed. This could influence the ${{callsite}}", assemblyName);
+                }
+            }
+        }
+#endif
     }
 }

--- a/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
+++ b/src/NLog.Extensions.Logging/Extensions/ConfigureExtensions.cs
@@ -187,7 +187,7 @@ namespace NLog.Extensions.Logging
             Guard.ThrowIfNull(factoryBuilder);
             AddNLogLoggerProvider(builder, null, options, (serviceProvider, config, options) =>
             {
-                serviceProvider.SetupNLogConfigSettings(config, LogManager.LogFactory);
+                config = serviceProvider.SetupNLogConfigSettings(config, LogManager.LogFactory);
 
                 // Delay initialization of targets until we have loaded config-settings
                 var logFactory = factoryBuilder(serviceProvider);
@@ -258,7 +258,7 @@ namespace NLog.Extensions.Logging
             if (configurationSection is null || !(configurationSection.GetChildren()?.Any() ?? false))
                 return options;
 
-            var configProps = options.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(p => p.SetMethod?.IsPublic == true).ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+            var configProps = typeof(NLogProviderOptions).GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(p => p.SetMethod?.IsPublic == true).ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
             foreach (var configValue in configurationSection.GetChildren())
             {
                 if (configProps.TryGetValue(configValue.Key, out var propertyInfo))

--- a/src/NLog.Extensions.Logging/LayoutRenderers/ConfigSettingLayoutRenderer.cs
+++ b/src/NLog.Extensions.Logging/LayoutRenderers/ConfigSettingLayoutRenderer.cs
@@ -28,6 +28,7 @@ namespace NLog.Extensions.Logging
     /// Config Setting Lookup Cached:
     ///      ${configsetting:cached=True:name=Mode}
     /// </example>
+    /// <seealso href="https://github.com/NLog/NLog/wiki/ConfigSetting-Layout-Renderer">Documentation on NLog Wiki</seealso>
     [LayoutRenderer("configsetting")]
     [ThreadAgnostic]
     public class ConfigSettingLayoutRenderer : LayoutRenderer

--- a/src/NLog.Extensions.Logging/LayoutRenderers/MicrosoftConsoleLayoutRenderer.cs
+++ b/src/NLog.Extensions.Logging/LayoutRenderers/MicrosoftConsoleLayoutRenderer.cs
@@ -8,6 +8,7 @@ namespace NLog.Extensions.Logging
     /// <summary>
     /// Renders output that simulates simple Microsoft Console Logger. Useful for Hosting Lifetime Startup Messages.
     /// </summary>
+    /// <seealso href="https://github.com/NLog/NLog/wiki/MicrosoftConsoleLayout">Documentation on NLog Wiki</seealso>
     [LayoutRenderer("MicrosoftConsoleLayout")]
     [ThreadAgnostic]
     class MicrosoftConsoleLayoutRenderer : LayoutRenderer

--- a/src/NLog.Extensions.Logging/Layouts/MicrosoftConsoleJsonLayout.cs
+++ b/src/NLog.Extensions.Logging/Layouts/MicrosoftConsoleJsonLayout.cs
@@ -10,6 +10,7 @@ namespace NLog.Extensions.Logging
     /// <summary>
     /// Renders output that simulates Microsoft Json Console Formatter from AddJsonConsole
     /// </summary>
+    /// <seealso href="https://github.com/NLog/NLog/wiki/MicrosoftConsoleJsonLayout">Documentation on NLog Wiki</seealso>
     [Layout("MicrosoftConsoleJsonLayout")]
     [ThreadAgnostic]
     public class MicrosoftConsoleJsonLayout : JsonLayout

--- a/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
@@ -264,8 +264,8 @@ namespace NLog.Extensions.Logging
                 return false;
             }
 
-            var keyPropertyInfo = itemType.GetDeclaredProperty("Key");
-            var valuePropertyInfo = itemType.GetDeclaredProperty("Value");
+            var keyPropertyInfo = typeof(KeyValuePair<,>).MakeGenericType(itemType.GenericTypeArguments).GetTypeInfo().GetDeclaredProperty("Key");
+            var valuePropertyInfo = typeof(KeyValuePair<,>).MakeGenericType(itemType.GenericTypeArguments).GetTypeInfo().GetDeclaredProperty("Value");
             if (valuePropertyInfo is null || keyPropertyInfo is null)
             {
                 return false;

--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -103,7 +103,7 @@ namespace NLog.Extensions.Logging
         {
             if (messageParameters.HasMessageTemplateSyntax(_options.ParseMessageTemplates))
             {
-                var originalMessage = messageParameters.GetOriginalMessage(messageProperties);
+                var originalMessage = messageParameters?.GetOriginalMessage(messageProperties);
                 var logEvent = new LogEventInfo(nLogLogLevel, _logger.Name, null, originalMessage, SingleItemArray);
                 var messageTemplateParameters = logEvent.MessageTemplateParameters;   // Forces parsing of OriginalMessage
                 if (messageTemplateParameters.Count > 0)

--- a/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLoggerProvider.cs
@@ -52,7 +52,6 @@ namespace NLog.Extensions.Logging
             LogFactory = logFactory ?? LogManager.LogFactory;
             Options = options ?? NLogProviderOptions.Default;
             _beginScopeParser = new NLogBeginScopeParser(options);
-            RegisterHiddenAssembliesForCallSite();
         }
 
         /// <summary>
@@ -92,47 +91,6 @@ namespace NLog.Extensions.Logging
                 }
             }
         }
-
-        /// <summary>
-        /// Ignore assemblies for ${callsite}
-        /// </summary>
-        private static void RegisterHiddenAssembliesForCallSite()
-        {
-            InternalLogger.Debug("Hide assemblies for callsite");
-            Config.ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(NLogLoggerProvider).GetTypeInfo().Assembly);
-
-            LogManager.AddHiddenAssembly(typeof(NLogLoggerProvider).GetTypeInfo().Assembly);
-            LogManager.AddHiddenAssembly(typeof(Microsoft.Extensions.Logging.ILogger).GetTypeInfo().Assembly);
-
-#if !NETCORE1_0
-            LogManager.AddHiddenAssembly(typeof(Microsoft.Extensions.Logging.LoggerFactory).GetTypeInfo().Assembly);
-#else
-            SafeAddHiddenAssembly("Microsoft.Logging");
-            SafeAddHiddenAssembly("Microsoft.Extensions.Logging");
-
-            //try the Filter ext, this one is not mandatory so could fail
-            SafeAddHiddenAssembly("Microsoft.Extensions.Logging.Filter", false);
-#endif
-        }
-
-#if NETCORE1_0
-        private static void SafeAddHiddenAssembly(string assemblyName, bool logOnException = true)
-        {
-            try
-            {
-                InternalLogger.Trace("Hide {0}", assemblyName);
-                var assembly = Assembly.Load(new AssemblyName(assemblyName));
-                LogManager.AddHiddenAssembly(assembly);
-            }
-            catch (Exception ex)
-            {
-                if (logOnException)
-                {
-                    InternalLogger.Debug(ex, "Hiding assembly {0} failed. This could influence the ${{callsite}}", assemblyName);
-                }
-            }
-        }
-#endif
     }
 }
 

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -39,6 +39,8 @@ List of major changes in NLog 5.0: https://nlog-project.org/2021/08/25/nlog-5-0-
     <LangVersion>latest</LangVersion>
     <!-- EmbedUntrackedSources for deterministic build -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -72,7 +74,7 @@ List of major changes in NLog 5.0: https://nlog-project.org/2021/08/25/nlog-5-0-
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.1.5" />
+    <PackageReference Include="NLog" Version="5.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/NLog.Extensions.Logging/Targets/MicrosoftILoggerTarget.cs
+++ b/src/NLog.Extensions.Logging/Targets/MicrosoftILoggerTarget.cs
@@ -12,6 +12,7 @@ namespace NLog.Extensions.Logging
     /// <summary>
     /// Forwards NLog LogEvents to Microsoft ILogger-interface with support for NLog Layout-features
     /// </summary>
+    /// <seealso href="https://github.com/NLog/NLog/wiki/MicrosoftILogger-Target">Documentation on NLog Wiki</seealso>
     [Target("MicrosoftILogger")]
     public class MicrosoftILoggerTarget : TargetWithContext
     {
@@ -33,6 +34,18 @@ namespace NLog.Extensions.Logging
         /// Override name of ILogger, when target has been initialized with <see cref="Microsoft.Extensions.Logging.ILoggerFactory"/>
         /// </summary>
         public Layout LoggerName { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MicrosoftILoggerTarget" /> class.
+        /// </summary>
+        public MicrosoftILoggerTarget()
+        {
+#if !NETSTANDARD1_3 && !NETSTANDARD1_5
+            _logger = Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+#else
+            _logger = new NLog.Extensions.Logging.NLogLogger(NLog.LogManager.CreateNullLogger(), null, new NLogBeginScopeParser(null));
+#endif
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MicrosoftILoggerTarget" /> class.

--- a/test/NLog.Extensions.Hosting.Tests/ExtensionMethodTests.cs
+++ b/test/NLog.Extensions.Hosting.Tests/ExtensionMethodTests.cs
@@ -76,7 +76,7 @@ namespace NLog.Extensions.Hosting.Tests
             try
             {
                 var nlogTarget = new Targets.MemoryTarget() { Name = "Output" };
-                Config.SimpleConfigurator.ConfigureForTargetLogging(nlogTarget, LogLevel.Fatal);
+                NLog.LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(nlogTarget));
 
                 var loggerFactory = host.Services.GetService<ILoggerFactory>();
                 Assert.NotNull(loggerFactory);

--- a/test/NLog.Extensions.Logging.Tests/ApiTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/ApiTests.cs
@@ -1,0 +1,343 @@
+﻿namespace NLog.Extensions.Logging.Tests
+{
+    using System;
+    using System.Linq;
+    using System.Text;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using NLog.Config;
+    using NLog.Extensions.Logging;
+    using NLog.LayoutRenderers;
+    using Xunit;
+
+    /// <summary>
+    /// Test the characteristics of the API. Config of the API is tested in <see cref="NLog.UnitTests.Config.ConfigApiTests"/>
+    /// </summary>
+    public class ApiTests
+    {
+        private readonly Type[] allTypes;
+        private readonly Assembly nlogExtensionAssembly = typeof(NLogLoggerFactory).Assembly;
+        private readonly Dictionary<Type, int> typeUsageCount = new Dictionary<Type, int>();
+
+        public ApiTests()
+        {
+            allTypes = nlogExtensionAssembly.GetTypes();
+        }
+
+        [Fact]
+        public void PublicEnumsTest()
+        {
+            foreach (Type type in allTypes)
+            {
+                if (!type.IsPublic)
+                {
+                    continue;
+                }
+
+                if (type.IsEnum || type.IsInterface)
+                {
+                    typeUsageCount[type] = 0;
+                }
+            }
+
+            typeUsageCount[typeof(IInstallable)] = 1;
+
+            foreach (Type type in allTypes)
+            {
+                if (type.IsGenericTypeDefinition)
+                {
+                    continue;
+                }
+
+                if (type.BaseType != null)
+                {
+                    IncrementUsageCount(type.BaseType);
+                }
+
+                foreach (var iface in type.GetInterfaces())
+                {
+                    IncrementUsageCount(iface);
+                }
+
+                foreach (var method in type.GetMethods())
+                {
+                    if (method.IsGenericMethodDefinition)
+                    {
+                        continue;
+                    }
+
+                    // Console.WriteLine("  {0}", method.Name);
+                    try
+                    {
+                        IncrementUsageCount(method.ReturnType);
+
+                        foreach (var p in method.GetParameters())
+                        {
+                            IncrementUsageCount(p.ParameterType);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // this sometimes throws on .NET Compact Framework, but is not fatal
+                        Console.WriteLine("EXCEPTION {0}", ex);
+                    }
+                }
+            }
+
+            var unusedTypes = new List<Type>();
+            StringBuilder sb = new StringBuilder();
+
+            foreach (var kvp in typeUsageCount)
+            {
+                if (kvp.Value == 0)
+                {
+                    Console.WriteLine("Type '{0}' is not used.", kvp.Key);
+                    unusedTypes.Add(kvp.Key);
+                    sb.Append(kvp.Key.FullName).Append("\n");
+                }
+            }
+
+            Assert.Empty(unusedTypes);
+        }
+
+        private void IncrementUsageCount(Type type)
+        {
+            if (type.IsArray)
+            {
+                type = type.GetElementType();
+            }
+
+            if (type.IsGenericType && !type.IsGenericTypeDefinition)
+            {
+                IncrementUsageCount(type.GetGenericTypeDefinition());
+                foreach (var parm in type.GetGenericArguments())
+                {
+                    IncrementUsageCount(parm);
+                }
+                return;
+            }
+
+            if (type.Assembly != nlogExtensionAssembly)
+            {
+                return;
+            }
+
+            if (typeUsageCount.ContainsKey(type))
+            {
+                typeUsageCount[type]++;
+            }
+        }
+
+        [Fact]
+        public void TypesInInternalNamespaceShouldBeInternalTest()
+        {
+            var notInternalTypes = allTypes
+                .Where(t => t.Namespace != null && t.Namespace.Contains(".Internal"))
+                .Where(t => !t.IsNested && (t.IsVisible || t.IsPublic))
+                .Select(t => t.FullName)
+                .ToList();
+
+            Assert.Empty(notInternalTypes);
+        }
+
+        [Fact]
+        public void AppDomainFixedOutput_Attribute_EnsureThreadAgnostic()
+        {
+            foreach (Type type in allTypes)
+            {
+                var appDomainFixedOutputAttribute = type.GetCustomAttribute<AppDomainFixedOutputAttribute>();
+                if (appDomainFixedOutputAttribute != null)
+                {
+                    var threadAgnosticAttribute = type.GetCustomAttribute<ThreadAgnosticAttribute>();
+                    Assert.True(!(threadAgnosticAttribute is null), $"{type.ToString()} is missing [ThreadAgnostic] attribute");
+                }
+            }
+        }
+
+        [Fact]
+        public void WrapperLayoutRenderer_EnsureThreadAgnostic()
+        {
+            foreach (Type type in allTypes)
+            {
+                if (typeof(NLog.LayoutRenderers.Wrappers.WrapperLayoutRendererBase).IsAssignableFrom(type))
+                {
+                    if (type.IsAbstract || !type.IsPublic)
+                        continue;   // skip non-concrete types, enumerations, and private nested types
+
+                    Assert.True(type.IsDefined(typeof(ThreadAgnosticAttribute), true), $"{type.ToString()} is missing [ThreadAgnostic] attribute.");
+                }
+            }
+        }
+
+        [Fact]
+        public void RequiredConfigOptionMustBeClass()
+        {
+            foreach (Type type in allTypes)
+            {
+                var properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                foreach (var prop in properties)
+                {
+                    var requiredParameter = prop.GetCustomAttribute<NLog.Config.RequiredParameterAttribute>();
+                    if (requiredParameter != null)
+                    {
+                        Assert.True(prop.PropertyType.IsClass, prop.Name);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void SingleDefaultConfigOption()
+        {
+            string prevDefaultPropertyName = null;
+
+            foreach (Type type in allTypes)
+            {
+                prevDefaultPropertyName = null;
+
+                var properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                foreach (var prop in properties)
+                {
+                    var defaultParameter = prop.GetCustomAttribute<DefaultParameterAttribute>();
+                    if (defaultParameter != null)
+                    {
+                        Assert.True(prevDefaultPropertyName == null, prevDefaultPropertyName?.ToString());
+                        prevDefaultPropertyName = prop.Name;
+                        Assert.True(type.IsSubclassOf(typeof(NLog.LayoutRenderers.LayoutRenderer)), type.ToString());
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void ValidateLayoutRendererTypeAlias()
+        {
+            // These class-names should be repaired with next major version bump
+            // Do NOT add more incorrect class-names to this exlusion-list
+            HashSet<string> oldFaultyClassNames = new HashSet<string>()
+            {
+                "MicrosoftConsoleLayoutRenderer",
+            };
+            foreach (Type type in allTypes)
+            {
+                if (type.IsSubclassOf(typeof(LayoutRenderer)))
+                {
+                    var layoutRendererAttributes = type.GetCustomAttributes<LayoutRendererAttribute>()?.ToArray() ?? new LayoutRendererAttribute[0];
+                    if (layoutRendererAttributes.Length == 0)
+                    {
+                        Assert.True(type.IsAbstract, $"{type} without LayoutRendererAttribute must be abstract");
+                    }
+                    else
+                    {
+                        Assert.False(type.IsAbstract, $"{type} with LayoutRendererAttribute cannot be abstract");
+
+                        if (!oldFaultyClassNames.Contains(type.Name))
+                        {
+                            var typeAlias = layoutRendererAttributes.First().Name.Replace("-", "");
+                            Assert.Equal(typeAlias + "LayoutRenderer", type.Name, StringComparer.OrdinalIgnoreCase);
+                        }
+                    }
+
+                    Assert.Equal("NLog.Extensions.Logging", type.Namespace);
+                }
+            }
+        }
+
+        [Fact]
+        public void ValidateConfigurationItemFactory()
+        {
+            ConfigurationItemFactory.Default = null;    // Reset
+
+            LogManager.Setup().SetupExtensions(ext => ext.RegisterConfigSettings(null));
+
+            var missingTypes = new List<string>();
+
+            foreach (Type type in allTypes)
+            {
+                if (!type.IsPublic || !type.IsClass || type.IsAbstract)
+                    continue;
+
+                if (typeof(NLog.Targets.Target).IsAssignableFrom(type))
+                {
+                    var configAttribs = type.GetCustomAttributes<NLog.Targets.TargetAttribute>(false);
+                    Assert.NotEmpty(configAttribs);
+
+                    foreach (var configName in configAttribs)
+                    {
+                        if (!ConfigurationItemFactory.Default.TargetFactory.TryCreateInstance(configName.Name, out var target))
+                        {
+                            Console.WriteLine(configName.Name);
+                            missingTypes.Add(configName.Name);
+                        }
+                        else if (type != target.GetType())
+                        {
+                            Console.WriteLine(type.Name);
+                            missingTypes.Add(type.Name);
+                        }
+                    }
+                }
+                else if (typeof(NLog.Layouts.Layout).IsAssignableFrom(type))
+                {
+                    var configAttribs = type.GetCustomAttributes<NLog.Layouts.LayoutAttribute>(false);
+                    Assert.NotEmpty(configAttribs);
+
+                    foreach (var configName in configAttribs)
+                    {
+                        if (!ConfigurationItemFactory.Default.LayoutFactory.TryCreateInstance(configName.Name, out var layout))
+                        {
+                            Console.WriteLine(configName.Name);
+                            missingTypes.Add(configName.Name);
+                        }
+                        else if (type != layout.GetType())
+                        {
+                            Console.WriteLine(type.Name);
+                            missingTypes.Add(type.Name);
+                        }
+                    }
+                }
+                else if (typeof(NLog.LayoutRenderers.LayoutRenderer).IsAssignableFrom(type))
+                {
+                    var configAttribs = type.GetCustomAttributes<NLog.LayoutRenderers.LayoutRendererAttribute>(false);
+                    Assert.NotEmpty(configAttribs);
+
+                    foreach (var configName in configAttribs)
+                    {
+                        if (!ConfigurationItemFactory.Default.LayoutRendererFactory.TryCreateInstance(configName.Name, out var layoutRenderer))
+                        {
+                            Console.WriteLine(configName.Name);
+                            missingTypes.Add(configName.Name);
+                        }
+                        else if (type != layoutRenderer.GetType())
+                        {
+                            Console.WriteLine(type.Name);
+                            missingTypes.Add(type.Name);
+                        }
+                    }
+
+                    if (typeof(NLog.LayoutRenderers.Wrappers.WrapperLayoutRendererBase).IsAssignableFrom(type))
+                    {
+                        var wrapperAttribs = type.GetCustomAttributes<NLog.LayoutRenderers.AmbientPropertyAttribute>(false);
+                        if (wrapperAttribs?.Any() == true)
+                        {
+                            foreach (var ambientName in wrapperAttribs)
+                            {
+                                if (!ConfigurationItemFactory.Default.AmbientRendererFactory.TryCreateInstance(ambientName.Name, out var layoutRenderer))
+                                {
+                                    Console.WriteLine(ambientName.Name);
+                                    missingTypes.Add(ambientName.Name);
+                                }
+                                else if (type != layoutRenderer.GetType())
+                                {
+                                    Console.WriteLine(type.Name);
+                                    missingTypes.Add(type.Name);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Assert.Empty(missingTypes);
+        }
+    }
+}

--- a/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
@@ -273,8 +273,9 @@ namespace NLog.Extensions.Logging.Tests
 
         private Runner GetRunner()
         {
-            ConfigureTransientService<Runner>((s) => LoggerProvider.LogFactory.LoadConfiguration("nlog.config"));
-            return base.GetRunner<Runner>();
+            var runner = base.GetRunner<Runner>();
+            LoggerProvider.LogFactory.Setup().LoadConfigurationFromFile("nlog.config");
+            return runner;
         }
 
         public class Runner

--- a/test/NLog.Extensions.Logging.Tests/NLogTestBase.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogTestBase.cs
@@ -13,15 +13,11 @@ namespace NLog.Extensions.Logging.Tests
         {
             if (_serviceProvider is null)
             {
-                var logFactory = new LogFactory();
-                LoggerProvider = new NLogLoggerProvider(options ?? new NLogProviderOptions { CaptureMessageTemplates = true, CaptureMessageProperties = true }, logFactory);
                 var services = new ServiceCollection();
-                services.AddSingleton<ILoggerFactory, LoggerFactory>();
-                services.AddSingleton(typeof(ILogger<>), typeof(Logger<>));
+                services.AddLogging(builder => builder.AddNLog(options ?? new NLogProviderOptions { CaptureMessageTemplates = true, CaptureMessageProperties = true }, provider => new LogFactory()));
                 configureServices?.Invoke(services);
                 _serviceProvider = services.BuildServiceProvider();
-                var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
-                loggerFactory.AddProvider(LoggerProvider);
+                LoggerProvider = _serviceProvider.GetRequiredService<ILoggerProvider>() as NLogLoggerProvider;
             }
             return LoggerProvider;
         }


### PR DESCRIPTION
- Update to NLog 5.2 - https://github.com/NLog/NLog/releases/tag/v5.2.0