### PR TITLE
Version 5.3.7

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,13 @@
 
 Date format: (year/month/day)
 
+### Version 5.3.7 (2023/12/06)
+
+**Improvements**
+- [#705](https://github.com/NLog/NLog.Extensions.Logging/pull/705): Added target platform for NET 8.0 (#705) (@snakefoot)
+- [#710](https://github.com/NLog/NLog.Extensions.Logging/pull/710): Improve XML docs for AddNLog and UseNLog (#710) (@snakefoot)
+- [#713](https://github.com/NLog/NLog.Extensions.Logging/pull/713): Updated to NLog v5.2.7 (#713) (@snakefoot)
+
 ### Version 5.3.5 (2023/10/15)
 
 **Improvements**

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@
 # creates NuGet package at \artifacts
 dotnet --version
 
-$versionPrefix = "5.3.5"
+$versionPrefix = "5.3.7"
 $versionSuffix = ""
 $versionFile = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
 $versionProduct = $versionPrefix;

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard1.3;netstandard1.5;netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <DebugType Condition=" '$(Configuration)' == 'Debug' ">Full</DebugType>
@@ -18,7 +18,9 @@ For ASP.NET Core, check: https://www.nuget.org/packages/NLog.Web.AspNetCore
     <PackageReleaseNotes>
 ChangeLog:
 
-- Updated to NLog v5.2.5 (#695) (@snakefoot)
+- Added target platform for NET 8.0 (#705) (@snakefoot)
+- Improve XML docs for AddNLog and UseNLog (#710) (@snakefoot)
+- Updated to NLog v5.2.7 (#713) (@snakefoot)
 
 Full changelog: https://github.com/NLog/NLog.Extensions.Logging/blob/master/CHANGELOG.MD
 


### PR DESCRIPTION
 **NLog Version 5.2.7 (2023/11/28)**
- [#5427](https://redirect.github.com/NLog/NLog/pull/5427) FileTarget - Fix Windows FileSystem Tunneling when KeepFileOpen=false ([#5427](https://redirect.github.com/NLog/NLog/issues/5427)) ([@​snakefoot](https://github.com/snakefoot))
- [#5422](https://redirect.github.com/NLog/NLog/pull/5422) AppEnvironmentWrapper - Added Entry-Assembly as fallback for ProcessName ([#5422](https://redirect.github.com/NLog/NLog/issues/5422)) ([@​snakefoot](https://github.com/snakefoot))
- [#5419](https://redirect.github.com/NLog/NLog/pull/5419) Improved XML docs for MDC, MDLC, NDC, NDLC about being replaced by ScopeContext ([#5419](https://redirect.github.com/NLog/NLog/issues/5419)) ([@​snakefoot](https://github.com/snakefoot))

**NLog Version 5.2.6 (2023/11/19)**
- [#5407](https://redirect.github.com/NLog/NLog/pull/5407) FileTarget - Added option WriteHeaderWhenInitialFileNotEmpty ([#5407](https://redirect.github.com/NLog/NLog/issues/5407)) ([@​RomanSoloweow](https://github.com/RomanSoloweow))
- [#5381](https://redirect.github.com/NLog/NLog/pull/5381) FileTarget - Removed explicit File.Create to not trigger file-scanners ([#5381](https://redirect.github.com/NLog/NLog/issues/5381)) ([@​snakefoot](https://github.com/snakefoot))
- [#5382](https://redirect.github.com/NLog/NLog/pull/5382) FileTarget - SetCreationTimeUtc only when IsArchivingEnabled ([#5382](https://redirect.github.com/NLog/NLog/issues/5382)) ([@​snakefoot](https://github.com/snakefoot))
- [#5384](https://redirect.github.com/NLog/NLog/pull/5384) FileTarget - SetCreationTimeUtc always when running on Windows ([#5384](https://redirect.github.com/NLog/NLog/issues/5384)) ([@​snakefoot](https://github.com/snakefoot))
- [#5389](https://redirect.github.com/NLog/NLog/pull/5389) ColoredConsoleTarget - Added Setup-extension-method WriteToColoredConsole ([#5389](https://redirect.github.com/NLog/NLog/issues/5389)) ([@​snakefoot](https://github.com/snakefoot))
- [#5409](https://redirect.github.com/NLog/NLog/pull/5409) MemoryTarget - Make Logs-property thread-safe to enumerate ([#5409](https://redirect.github.com/NLog/NLog/issues/5409)) ([@​snakefoot](https://github.com/snakefoot))
- [#5413](https://redirect.github.com/NLog/NLog/pull/5413) MultiFileWatcher - Improve InternalLogger output to match on start and stop ([#5413](https://redirect.github.com/NLog/NLog/issues/5413)) ([@​snakefoot](https://github.com/snakefoot))
- [#5398](https://redirect.github.com/NLog/NLog/pull/5398) Marked obsolete members with EditorBrowsableState.Never ([#5398](https://redirect.github.com/NLog/NLog/issues/5398)) ([@​snakefoot](https://github.com/snakefoot))
- [#5412](https://redirect.github.com/NLog/NLog/pull/5412) Change TargetFrameworks to net461 when old VisualStudioVersion ([#5412](https://redirect.github.com/NLog/NLog/issues/5412)) ([@​snakefoot](https://github.com/snakefoot))