### PR TITLE
Prevent obsolete warning on using property on framework greater than 6.0

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -60,7 +60,7 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public bool AutoShutdown { get; set; }
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         /// <summary>
         /// Automatically include <see cref="System.Diagnostics.Activity.SpanId"/>, <see cref="System.Diagnostics.Activity.TraceId"/> and <see cref="System.Diagnostics.Activity.ParentId"/>
         /// </summary>


### PR DESCRIPTION
When using NLog from a solution using .NET 7.0 or .NET 8.0, an obsolete warning is displayed when using the `IncludeActivityIdsWithBeginScope` property.

![image](https://github.com/NLog/NLog.Extensions.Logging/assets/37021716/1d3dd8cf-fa58-4508-92ba-3b6e8039bfd7)

This is caused by the preprocessor check that explicitly checks if the framework is .NET 6.0. Microsoft offers `NET6_0_OR_GREATER` that should prevent this warning when using frameworks greater than 6.0: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives