### PR TITLE
NLogMessageParameterList - Optimize check of CaptureType for index operator 

### DIFF
--- a/examples/NetCore2/HostingExample/HostingExample.csproj
+++ b/examples/NetCore2/HostingExample/HostingExample.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogMessageParameterList.cs
@@ -97,7 +97,6 @@ namespace NLog.Extensions.Logging
             string parameterName;
 
             var parameterCount = parameterList.Count;
-
             for (int i = 0; i < parameterCount; ++i)
             {
                 if (!TryGetParameterName(parameterList, i, out parameterName))
@@ -188,13 +187,19 @@ namespace NLog.Extensions.Logging
                     index += 1;
 
                 var parameter = _parameterList[index];
-                var parameterName = parameter.Key;
-                var capture = GetCaptureType(parameterName[0]);
-                if (capture != CaptureType.Normal)
-                    parameterName = parameterName.Substring(1);
-                return new MessageTemplateParameter(parameterName, parameter.Value, null, capture);
+                return _hasMessageTemplateCapture ?
+                    GetMessageTemplateParameter(parameter.Key, parameter.Value) :
+                    new MessageTemplateParameter(parameter.Key, parameter.Value, null, CaptureType.Normal);
             }
             set => throw new NotSupportedException();
+        }
+
+        private static MessageTemplateParameter GetMessageTemplateParameter(string parameterName, object parameterValue)
+        {
+            var capture = GetCaptureType(parameterName[0]);
+            if (capture != CaptureType.Normal)
+                parameterName = parameterName.Substring(1);
+            return new MessageTemplateParameter(parameterName, parameterValue, null, capture);
         }
 
         private static CaptureType GetCaptureType(char firstChar)

--- a/test/NLog.Extensions.Hosting.Tests/NLog.Extensions.Hosting.Tests.csproj
+++ b/test/NLog.Extensions.Hosting.Tests/NLog.Extensions.Hosting.Tests.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Skip check of `CaptureType` when not having MessageTemplateCapture.