### PR TITLE
Fallback to Microsoft Logging Formatter when mixing positional with structured

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLogger.cs
@@ -63,7 +63,7 @@ namespace NLog.Extensions.Logging
                             ?? CaputureBasicLogEvent(nLogLogLevel, formatter(state, exception), messagePropertyList, messageParameters);
                         CaptureEventIdProperties(logEvent, eventId);
                         return logEvent;
-}
+                    }
                     else
                     {
                         var logEvent = TryParseMessageTemplate(nLogLogLevel, messagePropertyList, messageParameters)
@@ -122,7 +122,7 @@ namespace NLog.Extensions.Logging
 
         private LogEventInfo TryParsePostionalMessageTemplate(LogLevel nLogLogLevel, IReadOnlyList<KeyValuePair<string, object>> messageProperties, NLogMessageParameterList messageParameters)
         {
-            if (messageParameters.IsPositional && _options.ParseMessageTemplates)
+            if (messageParameters.IsPositional && (messageParameters.HasComplexParameters || _options.ParseMessageTemplates))
             {
                 string originalMessage = TryParsePositionalParameters(messageProperties, out var parameters);
                 if (originalMessage != null)
@@ -258,7 +258,7 @@ namespace NLog.Extensions.Logging
             for (int i = 0; i < messageParameterCount; ++i)
             {
                 var propertyName = messageParameters[i].Name;
-                
+
                 bool extraProperty = true;
                 for (int j = startPos; j < messageTemplateParameters.Count; ++j)
                 {

--- a/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
@@ -220,9 +220,25 @@ namespace NLog.Extensions.Logging.Tests
         [Fact]
         public void TestInvalidFormatString2()
         {
-            var runner = GetRunner<Runner>(new NLogProviderOptions { CaptureMessageTemplates = false });
+            var runner = GetRunner<Runner>(new NLogProviderOptions { CaptureMessageTemplates = true });
             var ex = Assert.Throws<AggregateException>(() => runner.Logger.LogDebug("{0}{1}", "Test"));
             Assert.IsType<FormatException>(ex.InnerException);
+        }
+
+        [Fact]
+        public void TestInvalidMixFormatString()
+        {
+            var runner = GetRunner<Runner>();
+            runner.Logger.LogDebug("{0}{Mix}", "Mix", "Test");
+            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|MixTest|0=Mix, Mix=Test", runner.LastTargetMessage);
+        }
+
+        [Fact]
+        public void TestInvalidMixFormatString2()
+        {
+            var runner = GetRunner<Runner>(new NLogProviderOptions { CaptureMessageTemplates = true });
+            runner.Logger.LogDebug("{0}{Mix}", "Mix", "Test");
+            Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|MixTest|0=Mix, Mix=Test", runner.LastTargetMessage);
         }
 
         [Fact]

--- a/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/NLogMessageParameterListTests.cs
@@ -88,11 +88,9 @@ namespace NLog.Extensions.Logging.Tests
             };
             var list = NLogMessageParameterList.TryParse(items);
 
-            Assert.Equal(3, list.Count);
-            Assert.Equal(new MessageTemplateParameter("2", 1, null, CaptureType.Normal), list[0]);
-            Assert.Equal(new MessageTemplateParameter("1", 2, null, CaptureType.Normal), list[1]);
-            Assert.Equal(new MessageTemplateParameter("0", 3, null, CaptureType.Normal), list[2]);
+            Assert.Empty(list);
             Assert.True(list.HasComplexParameters);
+            Assert.True(list.IsPositional);
         }
 
         [Fact]


### PR DESCRIPTION
NLog expects message-template to be either positional or structured, and will complain when mixing.

Microsoft Logging Formatter treats all message-templates as structured-format (Not correctly support the positional format)