### PR TITLE
Fallback to Microsoft Logging Formatter when mixing positional with structured (test coverage)

### DIFF
--- a/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/LoggerTests.cs
@@ -220,7 +220,7 @@ namespace NLog.Extensions.Logging.Tests
         [Fact]
         public void TestInvalidFormatString2()
         {
-            var runner = GetRunner<Runner>(new NLogProviderOptions { CaptureMessageTemplates = true });
+            var runner = GetRunner<Runner>(new NLogProviderOptions { CaptureMessageTemplates = false });
             var ex = Assert.Throws<AggregateException>(() => runner.Logger.LogDebug("{0}{1}", "Test"));
             Assert.IsType<FormatException>(ex.InnerException);
         }
@@ -236,7 +236,7 @@ namespace NLog.Extensions.Logging.Tests
         [Fact]
         public void TestInvalidMixFormatString2()
         {
-            var runner = GetRunner<Runner>(new NLogProviderOptions { CaptureMessageTemplates = true });
+            var runner = GetRunner<Runner>(new NLogProviderOptions { CaptureMessageTemplates = false });
             runner.Logger.LogDebug("{0}{Mix}", "Mix", "Test");
             Assert.Equal("NLog.Extensions.Logging.Tests.LoggerTests.Runner|DEBUG|MixTest|0=Mix, Mix=Test", runner.LastTargetMessage);
         }


### PR DESCRIPTION
See also #756