### PR TITLE
NLogLoggingConfiguration - Fix memory-leak when using AutoReload

### DIFF
--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -87,7 +87,7 @@ List of major changes in NLog 5.0: https://nlog-project.org/2021/08/25/nlog-5-0-
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.3.3" />
+    <PackageReference Include="NLog" Version="5.3.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/test/NLog.Extensions.Hosting.Tests/NLog.Extensions.Hosting.Tests.csproj
+++ b/test/NLog.Extensions.Hosting.Tests/NLog.Extensions.Hosting.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/test/NLog.Extensions.Logging.Tests/NLog.Extensions.Logging.Tests.csproj
+++ b/test/NLog.Extensions.Logging.Tests/NLog.Extensions.Logging.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Trying to resolve #759 by avoiding double-registration on the config-changed-event.