### PR TITLE
MicrosoftConsoleJsonLayout - Skip Encode for Timestamp and LogLevel

### DIFF
--- a/src/NLog.Extensions.Logging/Layouts/MicrosoftConsoleJsonLayout.cs
+++ b/src/NLog.Extensions.Logging/Layouts/MicrosoftConsoleJsonLayout.cs
@@ -17,16 +17,16 @@ namespace NLog.Extensions.Logging
     {
         private static readonly string[] EventIdMapper = Enumerable.Range(0, 50).Select(id => id.ToString(System.Globalization.CultureInfo.InvariantCulture)).ToArray();
 
-        private readonly SimpleLayout _timestampLayout = new SimpleLayout("${date:format=o:universalTime=true}");
+        private readonly SimpleLayout _timestampLayout = new SimpleLayout("\"${date:format=o:universalTime=true}\"");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MicrosoftConsoleJsonLayout" /> class.
         /// </summary>
         public MicrosoftConsoleJsonLayout()
         {
-            Attributes.Add(new JsonAttribute("Timestamp", _timestampLayout));
+            Attributes.Add(new JsonAttribute("Timestamp", _timestampLayout) { Encode = false });
             Attributes.Add(new JsonAttribute("EventId", Layout.FromMethod(evt => LookupEventId(evt), LayoutRenderOptions.ThreadAgnostic)) { Encode = false });
-            Attributes.Add(new JsonAttribute("LogLevel", Layout.FromMethod(evt => ConvertLogLevel(evt.Level), LayoutRenderOptions.ThreadAgnostic)));
+            Attributes.Add(new JsonAttribute("LogLevel", Layout.FromMethod(evt => ConvertLogLevel(evt.Level), LayoutRenderOptions.ThreadAgnostic)) { Encode = false });
             Attributes.Add(new JsonAttribute("Category", "${logger}"));
             Attributes.Add(new JsonAttribute("Message", "${message}"));
             Attributes.Add(new JsonAttribute("Exception", "${replace-newlines:${exception:format=tostring,data}}"));
@@ -79,7 +79,7 @@ namespace NLog.Extensions.Logging
             get
             {
                 var index = LookupNamedAttributeIndex("Timestamp");
-                return index >= 0 ? ((Attributes[index].Layout as SimpleLayout)?.LayoutRenderers?.FirstOrDefault() as DateLayoutRenderer)?.Format : null;
+                return index >= 0 ? ((Attributes[index].Layout as SimpleLayout)?.LayoutRenderers?.OfType<DateLayoutRenderer>().FirstOrDefault())?.Format : null;
             }
             set
             {
@@ -91,9 +91,9 @@ namespace NLog.Extensions.Logging
                 
                 if (!string.IsNullOrEmpty(value))
                 {
-                    var dateLayoutRenderer = _timestampLayout.LayoutRenderers.First() as DateLayoutRenderer;
+                    var dateLayoutRenderer = _timestampLayout.LayoutRenderers.OfType<DateLayoutRenderer>().First();
                     dateLayoutRenderer.Format = value;
-                    Attributes.Insert(0, new JsonAttribute("Timestamp", _timestampLayout));
+                    Attributes.Insert(0, new JsonAttribute("Timestamp", _timestampLayout) { Encode = false });
                 }
             }
         }
@@ -144,17 +144,17 @@ namespace NLog.Extensions.Logging
         private static string ConvertLogLevel(LogLevel logLevel)
         {
             if (logLevel == LogLevel.Trace)
-                return nameof(Microsoft.Extensions.Logging.LogLevel.Trace);
+                return "\"" + nameof(Microsoft.Extensions.Logging.LogLevel.Trace) + "\"";
             else if (logLevel == LogLevel.Debug)
-                return nameof(Microsoft.Extensions.Logging.LogLevel.Debug);
+                return "\"" + nameof(Microsoft.Extensions.Logging.LogLevel.Debug) + "\"";
             else if (logLevel == LogLevel.Info)
-                return nameof(Microsoft.Extensions.Logging.LogLevel.Information);
+                return "\"" + nameof(Microsoft.Extensions.Logging.LogLevel.Information) + "\"";
             else if (logLevel == LogLevel.Warn)
-                return nameof(Microsoft.Extensions.Logging.LogLevel.Warning);
+                return "\"" + nameof(Microsoft.Extensions.Logging.LogLevel.Warning) + "\"";
             else if (logLevel == LogLevel.Error)
-                return nameof(Microsoft.Extensions.Logging.LogLevel.Error);
+                return "\"" + nameof(Microsoft.Extensions.Logging.LogLevel.Error) + "\"";
             else
-                return nameof(Microsoft.Extensions.Logging.LogLevel.Critical);
+                return "\"" + nameof(Microsoft.Extensions.Logging.LogLevel.Critical) + "\"";
         }
     }
 }

--- a/test/NLog.Extensions.Logging.Tests/MicrosoftConsoleJsonLayoutTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/MicrosoftConsoleJsonLayoutTests.cs
@@ -18,6 +18,15 @@ namespace NLog.Extensions.Logging.Tests
         }
 
         [Fact]
+        public void MicrosoftConsoleJsonLayout_TimestampFormat()
+        {
+            var layout = new MicrosoftConsoleJsonLayout() { TimestampFormat = "R" };
+            var logEvent = new LogEventInfo(LogLevel.Error, "MyLogger", "Hello World");
+            var result = layout.Render(logEvent);
+            Assert.Equal($"{{ \"Timestamp\": \"{logEvent.TimeStamp.ToUniversalTime().ToString("R")}\", \"EventId\": {0}, \"LogLevel\": \"Error\", \"Category\": \"MyLogger\", \"Message\": \"Hello World\", \"State\": {{ \"{{OriginalFormat}}\": \"Hello World\" }} }}", result);
+        }
+
+        [Fact]
         public void MicrosoftConsoleJsonLayout_ExceptionEvent()
         {
             var layout = new MicrosoftConsoleJsonLayout();


### PR DESCRIPTION
Skip verification of characters that must be json-encoded for TimeStamp and LogLevel for better performance.