### PR TITLE
Introduced AddNLog for IServiceCollection

### DIFF
--- a/src/NLog.Extensions.Logging/Config/NLogLoggingConfiguration.cs
+++ b/src/NLog.Extensions.Logging/Config/NLogLoggingConfiguration.cs
@@ -303,7 +303,7 @@ namespace NLog.Extensions.Logging
                 }
             }
 
-            private IEnumerable<IConfigurationSection> GetVariablesChildren(IConfigurationSection variables)
+            private static IEnumerable<IConfigurationSection> GetVariablesChildren(IConfigurationSection variables)
             {
                 List<KeyValuePair<string, IConfigurationSection>> sortVariables = null;
                 foreach (var variable in variables.GetChildren())

--- a/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
+++ b/src/NLog.Extensions.Logging/Internal/RegisterNLogLoggingProvider.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Linq;
-    using System.Reflection;
     using Microsoft.Extensions.Configuration;
 #if !NETCORE1_0
     using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
With https://github.com/dotnet/runtime/issues/61634#issuecomment-1033038101 and https://github.com/dotnet/runtime/pull/65109, Microsoft.Extensions.Hosting added a new way of creating a hosted app that doesn't use IHostBuilder.

See also https://github.com/dotnet/runtime/pull/68580 and https://github.com/dotnet/aspnetcore/pull/43056

Notice the new `AddNLog`-methods behaves like `AddNLog` for ILoggingBuilder with limited support for applying host-builder-configuration and host-builder-rootdir. It is recommended to use `UseNLog` for better integration with the host-builder. See also #780