### PR TITLE
MicrosoftConsoleJsonLayout - Added IncludeTrackingIds to output TraceId + SpanId + ParentId

### DIFF
--- a/src/NLog.Extensions.Logging/Layouts/MicrosoftConsoleJsonLayout.cs
+++ b/src/NLog.Extensions.Logging/Layouts/MicrosoftConsoleJsonLayout.cs
@@ -73,6 +73,42 @@ namespace NLog.Extensions.Logging
         }
 
         /// <summary>
+        /// Gets or sets whether to include "TraceId" + "SpanId" + "ParentId" in the output.
+        /// </summary>
+        /// <remarks>
+        /// Similar to ActivityTrackingOptions.TraceId | ActivityTrackingOptions.SpanId | ActivityTrackingOptions.ParentId .
+        ///
+        /// For additional Activity properties, use <see cref="StateAttributes"/> together with NLog.DiagnosticSource-nuget-package.
+        /// </remarks>
+        public bool IncludeTrackingIds
+        {
+            get => LookupNamedAttributeIndex("TraceId") >= 0;
+            set
+            {
+                var index_traceId = LookupNamedAttributeIndex("TraceId");
+                if (index_traceId >= 0)
+                {
+                    if (!value)
+                    {
+                        Attributes.RemoveAt(index_traceId);
+                        var index_spanId = LookupNamedAttributeIndex("SpanId");
+                        if (index_spanId >= 0)
+                            Attributes.RemoveAt(index_spanId);
+                        var index_parentId = LookupNamedAttributeIndex("ParentId");
+                        if (index_parentId >= 0)
+                            Attributes.RemoveAt(index_parentId);
+                    }
+                }
+                else if (value)
+                {
+                    Attributes.Add(new JsonAttribute("TraceId", Layout.FromMethod(l => ActivityExtensions.GetTraceId(System.Diagnostics.Activity.Current))));
+                    Attributes.Add(new JsonAttribute("SpanId", Layout.FromMethod(l => ActivityExtensions.GetSpanId(System.Diagnostics.Activity.Current))));
+                    Attributes.Add(new JsonAttribute("ParentId", Layout.FromMethod(l => ActivityExtensions.GetParentId(System.Diagnostics.Activity.Current))));
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets whether to include "Timestamp"-section
         /// </summary>
         public string? TimestampFormat

--- a/src/NLog.Extensions.Logging/Logging/ActivityExtensions.cs
+++ b/src/NLog.Extensions.Logging/Logging/ActivityExtensions.cs
@@ -1,6 +1,4 @@
-﻿#if NET5_0_OR_GREATER
-
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace NLog.Extensions.Logging
 {
@@ -9,36 +7,49 @@ namespace NLog.Extensions.Logging
     /// </summary>
     internal static class ActivityExtensions
     {
-        public static string GetSpanId(this Activity activity)
+        private static readonly string EmptySpanIdToHexString = default(System.Diagnostics.ActivitySpanId).ToHexString();
+        private static readonly string EmptyTraceIdToHexString = default(System.Diagnostics.ActivityTraceId).ToHexString();
+
+        public static string GetSpanId(this Activity? activity)
         {
-            return activity.IdFormat switch
+            return activity?.IdFormat switch
             {
                 ActivityIdFormat.Hierarchical => activity.Id,
-                ActivityIdFormat.W3C => activity.SpanId.ToHexString(),
+                ActivityIdFormat.W3C => SpanIdToHexString(activity.SpanId),
                 _ => null,
             } ?? string.Empty;
         }
 
-        public static string GetTraceId(this Activity activity)
+        public static string GetTraceId(this Activity? activity)
         {
-            return activity.IdFormat switch
+            return activity?.IdFormat switch
             {
                 ActivityIdFormat.Hierarchical => activity.RootId,
-                ActivityIdFormat.W3C => activity.TraceId.ToHexString(),
+                ActivityIdFormat.W3C => TraceIdToHexString(activity.TraceId),
                 _ => null,
             } ?? string.Empty;
         }
 
-        public static string GetParentId(this Activity activity)
+        public static string GetParentId(this Activity? activity)
         {
-            return activity.IdFormat switch
+            return activity?.IdFormat switch
             {
                 ActivityIdFormat.Hierarchical => activity.ParentId,
-                ActivityIdFormat.W3C => activity.ParentSpanId.ToHexString(),
+                ActivityIdFormat.W3C => SpanIdToHexString(activity.ParentSpanId),
                 _ => null,
             } ?? string.Empty;
+        }
+
+        private static string SpanIdToHexString(ActivitySpanId spanId)
+        {
+            var spanIdString = spanId.ToHexString();
+            return EmptySpanIdToHexString.Equals(spanIdString, System.StringComparison.Ordinal) ? string.Empty : spanIdString;
+        }
+
+        private static string TraceIdToHexString(ActivityTraceId traceId)
+        {
+            var traceIdString = traceId.ToHexString();
+            return EmptyTraceIdToHexString.Equals(traceIdString, System.StringComparison.Ordinal) ? string.Empty : traceIdString;
         }
     }
 }
-
-#endif

--- a/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogBeginScopeParser.cs
@@ -102,7 +102,6 @@ namespace NLog.Extensions.Logging
             }
         }
 
-#if NET5_0_OR_GREATER
         private IReadOnlyList<KeyValuePair<string, object?>> IncludeActivityIdsProperties(IReadOnlyList<KeyValuePair<string, object?>> scopePropertyList)
         {
             if (_options.IncludeActivityIdsWithBeginScope && "RequestId".Equals(scopePropertyList[0].Key))
@@ -165,12 +164,6 @@ namespace NLog.Extensions.Logging
                 return ((IEnumerable)_originalPropertyList).GetEnumerator();
             }
         }
-#else
-        private static IReadOnlyList<KeyValuePair<string, object?>> IncludeActivityIdsProperties(IReadOnlyList<KeyValuePair<string, object?>> scopePropertyList)
-        {
-            return scopePropertyList;   // Not supported
-        }
-#endif
 
         public static IDisposable CaptureScopeProperties(IEnumerable scopePropertyCollection, ExtractorDictionary stateExtractor)
         {

--- a/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogProviderOptions.cs
@@ -60,7 +60,6 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public bool AutoShutdown { get; set; }
 
-#if NET5_0_OR_GREATER
         /// <summary>
         /// Automatically include <see cref="System.Diagnostics.Activity.SpanId"/>, <see cref="System.Diagnostics.Activity.TraceId"/> and <see cref="System.Diagnostics.Activity.ParentId"/>
         /// </summary>
@@ -69,17 +68,6 @@ namespace NLog.Extensions.Logging
         /// 
         /// Consider using <a href="https://www.nuget.org/packages/NLog.DiagnosticSource/">${activity}</a> as alternative
         /// </remarks>
-#else
-        /// <summary>
-        /// Automatically include Activity.SpanId, Activity.TraceId and Activity.ParentId.
-        /// </summary>
-        /// <remarks>
-        /// Intended for Net5.0 where these properties are no longer included by default for performance reasons
-        /// 
-        /// Consider using <a href="https://www.nuget.org/packages/NLog.DiagnosticSource/">${activity}</a> as alternative
-        /// </remarks>
-        [Obsolete("Only supported with NET6 (or newer)")]
-#endif
         public bool IncludeActivityIdsWithBeginScope { get; set; }
 
         /// <summary>

--- a/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/Extensions/ConfigureExtensionsTests.cs
@@ -12,7 +12,6 @@ namespace NLog.Extensions.Logging.Tests.Extensions
 {
     public class ConfigureExtensionsTests
     {
-#if NET5_0_OR_GREATER
         [Fact]
         public void AddNLog_LoggerFactory_IncludeActivityIdsWithBeginScope()
         {
@@ -23,7 +22,7 @@ namespace NLog.Extensions.Logging.Tests.Extensions
             // Act
             LogManager.Configuration = config;
             var logger = loggerFactory.CreateLogger(nameof(AddNLog_LoggerFactory_IncludeActivityIdsWithBeginScope));
-            var activity = new System.Diagnostics.Activity("TestActivity").SetParentId("42").Start();
+            var _ = new System.Diagnostics.Activity("TestActivity").SetParentId("42").Start();
             var scopeProperties = new Dictionary<string, object> { { "RequestId", "123" }, { "RequestPath", "Unknown" } };
             using (logger.BeginScope(new ArraySegment<KeyValuePair<string, object>>(scopeProperties.ToArray())))
             {
@@ -33,7 +32,6 @@ namespace NLog.Extensions.Logging.Tests.Extensions
             // Assert
             AssertSingleMessage(memoryTarget, "42 - test message with 1 arg");
         }
-#endif
 
         [Fact]
         public void AddNLog_LoggingBuilder_LogInfo_ShouldLogToNLog()

--- a/test/NLog.Extensions.Logging.Tests/MicrosoftConsoleJsonLayoutTests.cs
+++ b/test/NLog.Extensions.Logging.Tests/MicrosoftConsoleJsonLayoutTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -67,6 +68,28 @@ namespace NLog.Extensions.Logging.Tests
             logger.Log(logEvent);
             var result = logFactory.Configuration.FindTargetByName<NLog.Targets.MemoryTarget>("test")?.Logs?.FirstOrDefault();
             Assert.Equal($"{{ \"Timestamp\": \"{logEvent.TimeStamp.ToUniversalTime().ToString("O")}\", \"EventId\": {eventId}, \"LogLevel\": \"Error\", \"Category\": \"{typeof(MicrosoftConsoleJsonLayoutTests).FullName}\", \"Message\": \"Alert {eventId}\", \"Exception\": \"{exception.ToString()}\", \"State\": {{ \"{{OriginalFormat}}\": \"Alert {{EventId}}\" }}, \"Scopes\": [ \"Request Started\", \"Activity Started\" ] }}", result);
+        }
+
+        [Fact]
+        public void MicrosoftConsoleJsonLayout_IncludeTrackingIds()
+        {
+            // Arrange
+            var logFactory = new LogFactory().Setup().LoadConfiguration(builder =>
+            {
+                var layout = new MicrosoftConsoleJsonLayout() { IncludeTrackingIds = true };
+                builder.ForLogger().WriteTo(new NLog.Targets.MemoryTarget("test") { Layout = layout });
+            }).LogFactory;
+            var logger = logFactory.GetCurrentClassLogger();
+
+            // Act
+            var _ = new System.Diagnostics.Activity("TestActivity").SetParentId("42").Start();
+            var eventId = 42;
+            var logEvent = new LogEventInfo(LogLevel.Info, "MyLogger", null, "Alert {EventId}", new object[] { eventId });
+            logger.Info(logEvent);
+
+            // Assert
+            var result = logFactory.Configuration.FindTargetByName<NLog.Targets.MemoryTarget>("test")?.Logs?.FirstOrDefault();
+            Assert.StartsWith($"{{ \"Timestamp\": \"{logEvent.TimeStamp.ToUniversalTime().ToString("O")}\", \"EventId\": {eventId}, \"LogLevel\": \"Information\", \"Category\": \"{typeof(MicrosoftConsoleJsonLayoutTests).FullName}\", \"Message\": \"Alert {eventId}\", \"State\": {{ \"{{OriginalFormat}}\": \"Alert {{EventId}}\" }}, \"TraceId\": \"42\", \"SpanId\": \"|42", result);
         }
     }
 }


### PR DESCRIPTION
Similar to `ActivityTrackingOptions.TraceId | ActivityTrackingOptions.SpanId | ActivityTrackingOptions.ParentId`

For additional Activity properties, use <see cref="StateAttributes"/> together with [NLog.DiagnosticSource](https://github.com/NLog/NLog.DiagnosticSource)-nuget-package.