### PR TITLE
NLogLoggerFactory DisposeAsync with ConfigureAwait(false)

### DIFF
--- a/src/NLog.Extensions.Logging/Logging/NLogLoggerFactory.cs
+++ b/src/NLog.Extensions.Logging/Logging/NLogLoggerFactory.cs
@@ -111,7 +111,7 @@ namespace NLog.Extensions.Logging
         /// </summary>
         public async System.Threading.Tasks.ValueTask DisposeAsync()
         {
-            await _provider.DisposeAsync();
+            await _provider.DisposeAsync().ConfigureAwait(false);
             GC.SuppressFinalize(this);
         }
 #endif


### PR DESCRIPTION
When NLogLoggerFactory.DisposeAsync() is called from the UI thread, it can result in a deadlock because the continuation is requested on the UI thread. This simple fix resolves that issue.