### PR TITLE
Version 6.2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,12 @@
 
 Date format: (year/month/day)
 
+### Version 6.2 (2026/08/16)
+- [#859](https://github.com/NLog/NLog.Extensions.Logging/pull/859) Updated to NLog v6.2 (@snakefoot)
+- [#855](https://github.com/NLog/NLog.Extensions.Logging/pull/855) Updated tutorials and examples for using NLog with Microsoft.Extension.Logging (@snakefoot)
+
+Release notes for NLog v6.2: https://nlog-project.org/2026/08/16/nlog-6-2-aot-build-size.html
+
 ### Version 6.1.4 (2026/07/08)
 - [#852](https://github.com/NLog/NLog.Extensions.Logging/pull/852) Updated to NLog v6.1.4 (@snakefoot)
 - [#850](https://github.com/NLog/NLog.Extensions.Logging/pull/850) Fix Sonar Code Smells (@snakefoot)

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@
 # creates NuGet package at \artifacts
 dotnet --version
 
-$versionPrefix = "6.1.4"
+$versionPrefix = "6.2.0"
 $versionSuffix = ""
 $versionFile = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
 $versionProduct = $versionPrefix;

--- a/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
+++ b/src/NLog.Extensions.Logging/NLog.Extensions.Logging.csproj
@@ -20,9 +20,8 @@ For ASP.NET Core, check: https://www.nuget.org/packages/NLog.Web.AspNetCore
     <PackageReleaseNotes>
 ChangeLog:
 
-- [#852] Updated to NLog v6.1.4 (@snakefoot)
-- [#850] Fix Sonar Code Smells (@snakefoot)
-- [#847] AppVeyor - Visual Studio 2026 (@snakefoot)
+- [#859] Updated to NLog v6.2 (@snakefoot)
+- [#855] Updated tutorials and examples for using NLog with Microsoft.Extension.Logging (@snakefoot)
 
 Full changelog: https://github.com/NLog/NLog.Extensions.Logging/blob/master/CHANGELOG.MD
 
@@ -77,7 +76,7 @@ List of major changes in NLog 6.0: https://nlog-project.org/2025/04/29/nlog-6-0-
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="NLog" Version="6.1.4" />
+    <PackageReference Include="NLog" Version="6.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">


### PR DESCRIPTION
- https://github.com/NLog/NLog/releases/tag/v6.2.0

Release notes for NLog v6.2: https://nlog-project.org/2026/08/16/nlog-6-2-aot-build-size.html